### PR TITLE
[Feature] 로그아웃 및 회원탈퇴 API 연동

### DIFF
--- a/core/data/src/main/java/com/example/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/example/data/repository/AuthRepositoryImpl.kt
@@ -73,7 +73,7 @@ class AuthRepositoryImpl @Inject constructor(
         authDataSource.logout()
     }
 
-    override suspend fun unRegisterUser(): Result<Unit> = suspendRunCatching {
-       authDataSource.unRegisterUser()
+    override suspend fun unregisterUser(): Result<Unit> = suspendRunCatching {
+       authDataSource.unregisterUser()
     }
 }

--- a/core/data/src/main/java/com/example/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/example/data/repository/AuthRepositoryImpl.kt
@@ -69,5 +69,11 @@ class AuthRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun logOut(): Result<Unit> = suspendRunCatching {
+        authDataSource.logout()
+    }
 
+    override suspend fun unRegisterUser(): Result<Unit> = suspendRunCatching {
+       authDataSource.unRegisterUser()
+    }
 }

--- a/core/domain/src/main/java/com/example/domain/repository/AuthRepository.kt
+++ b/core/domain/src/main/java/com/example/domain/repository/AuthRepository.kt
@@ -16,5 +16,5 @@ interface AuthRepository {
 
     suspend fun logOut(): Result<Unit>
 
-    suspend fun unRegisterUser(): Result<Unit>
+    suspend fun unregisterUser(): Result<Unit>
 }

--- a/core/domain/src/main/java/com/example/domain/repository/AuthRepository.kt
+++ b/core/domain/src/main/java/com/example/domain/repository/AuthRepository.kt
@@ -3,9 +3,18 @@ package com.example.domain.repository
 import com.example.domain.model.auth.User
 
 interface AuthRepository {
-    suspend fun loginKakao(idToken : String) : Result<User>
-    suspend fun registerUser(signUpToken : String, providerId : String, nickName : String, profileImageUrl : String?) : Result<Unit>
-    suspend fun saveFake() : Result<Unit>
-//    suspend fun logOut() : Result<Unit>
-//    suspend fun withdraw() : Result<Unit>
+    suspend fun loginKakao(idToken: String): Result<User>
+
+    suspend fun registerUser(
+        signUpToken: String,
+        providerId: String,
+        nickName: String,
+        profileImageUrl: String?
+    ): Result<Unit>
+
+    suspend fun saveFake(): Result<Unit>
+
+    suspend fun logOut(): Result<Unit>
+
+    suspend fun unRegisterUser(): Result<Unit>
 }

--- a/core/network/src/main/java/com/example/network/api/TraceApi.kt
+++ b/core/network/src/main/java/com/example/network/api/TraceApi.kt
@@ -80,4 +80,9 @@ interface TraceApi {
         @Path("commentId") commentId: Int,
     ): Result<Unit>
 
+    @POST("/api/v1/user/logout")
+    suspend fun logout() : Result<Unit>
+
+    @POST("/api/v1/user/delete")
+    suspend fun unRegisterUser() : Result<Unit>
 }

--- a/core/network/src/main/java/com/example/network/api/TraceApi.kt
+++ b/core/network/src/main/java/com/example/network/api/TraceApi.kt
@@ -84,5 +84,5 @@ interface TraceApi {
     suspend fun logout() : Result<Unit>
 
     @POST("/api/v1/user/delete")
-    suspend fun unRegisterUser() : Result<Unit>
+    suspend fun unregisterUser() : Result<Unit>
 }

--- a/core/network/src/main/java/com/example/network/source/auth/AuthDataSource.kt
+++ b/core/network/src/main/java/com/example/network/source/auth/AuthDataSource.kt
@@ -18,5 +18,5 @@ interface AuthDataSource {
 
     suspend fun logout() : Result<Unit>
 
-    suspend fun unRegisterUser() : Result<Unit>
+    suspend fun unregisterUser() : Result<Unit>
 }

--- a/core/network/src/main/java/com/example/network/source/auth/AuthDataSource.kt
+++ b/core/network/src/main/java/com/example/network/source/auth/AuthDataSource.kt
@@ -15,4 +15,8 @@ interface AuthDataSource {
     ): Result<TokenResponse>
 
     suspend fun checkTokenHealth(token : String) : Boolean
+
+    suspend fun logout() : Result<Unit>
+
+    suspend fun unRegisterUser() : Result<Unit>
 }

--- a/core/network/src/main/java/com/example/network/source/auth/AuthDataSourceImpl.kt
+++ b/core/network/src/main/java/com/example/network/source/auth/AuthDataSourceImpl.kt
@@ -69,6 +69,10 @@ class AuthDataSourceImpl @Inject constructor(
 
     override suspend fun checkTokenHealth(token: String): Boolean = traceApi.checkTokenHealth(token).isSuccess
 
+    override suspend fun logout(): Result<Unit> = traceApi.logout()
+
+    override suspend fun unRegisterUser(): Result<Unit> = traceApi.unRegisterUser()
+
     companion object {
         private const val WEBP_MEDIA_TYPE = "image/webp"
         private const val JPEG_MEDIA_TYPE = "image/jpeg"

--- a/core/network/src/main/java/com/example/network/source/auth/AuthDataSourceImpl.kt
+++ b/core/network/src/main/java/com/example/network/source/auth/AuthDataSourceImpl.kt
@@ -71,7 +71,7 @@ class AuthDataSourceImpl @Inject constructor(
 
     override suspend fun logout(): Result<Unit> = traceApi.logout()
 
-    override suspend fun unRegisterUser(): Result<Unit> = traceApi.unRegisterUser()
+    override suspend fun unregisterUser(): Result<Unit> = traceApi.unregisterUser()
 
     companion object {
         private const val WEBP_MEDIA_TYPE = "image/webp"

--- a/feature/mypage/src/main/java/com/example/mypage/graph/setting/SettingScreen.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/graph/setting/SettingScreen.kt
@@ -14,14 +14,20 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.common.util.clickable
 import com.example.designsystem.R
+import com.example.designsystem.component.CheckCancelDialog
 import com.example.designsystem.theme.PrimaryDefault
 import com.example.designsystem.theme.Red
 import com.example.designsystem.theme.TraceTheme
@@ -45,17 +51,43 @@ internal fun SettingRoute(
 
     SettingScreen(
         navigateBack = navigateBack,
-        signOut = viewModel::signOut,
-        unRegisterUser = viewModel::UnRegisterUser
+        logOut = viewModel::logOut,
+        unRegisterUser = viewModel::unRegisterUser
     )
 }
 
 @Composable
 private fun SettingScreen(
     navigateBack: () -> Unit,
-    signOut: () -> Unit,
+    logOut: () -> Unit,
     unRegisterUser: () -> Unit
 ) {
+    var showLogOutDialog by remember { mutableStateOf(false) }
+    var showUnRegisterUserDialog by remember { mutableStateOf(false) }
+
+    if (showLogOutDialog) {
+        CheckCancelDialog(
+            onCheck = {
+                logOut()
+                showLogOutDialog = false
+            },
+            onDismiss = { showLogOutDialog = false },
+            dialogText = "정말 로그아웃 하시겠습니까?"
+        )
+    }
+
+    if (showUnRegisterUserDialog) {
+        CheckCancelDialog(
+            onCheck = {
+                unRegisterUser()
+                showUnRegisterUserDialog = false
+            },
+            onDismiss = { showUnRegisterUserDialog = false },
+            dialogText = "정말 회원탈퇴 하시겠습니까?"
+        )
+    }
+
+
     Box(
         modifier = Modifier.fillMaxSize()
     ) {
@@ -64,18 +96,18 @@ private fun SettingScreen(
                 .fillMaxSize()
                 .padding(top = 80.dp, start = 30.dp, end = 20.dp)
         ) {
-            Text("로그아웃", style = TraceTheme.typography.bodyMSB, modifier = Modifier.clickable {
-
+            Text("로그아웃", style = TraceTheme.typography.bodyMR.copy(fontSize = 20.sp, lineHeight = 24.sp), modifier = Modifier.clickable {
+                showLogOutDialog = true
             })
 
             Spacer(Modifier.height(17.dp))
 
             Text(
                 "회원 탈퇴",
-                style = TraceTheme.typography.bodyMSB,
+                style = TraceTheme.typography.bodyMR.copy(fontSize = 20.sp, lineHeight = 24.sp),
                 color = Red,
                 modifier = Modifier.clickable {
-
+                    showUnRegisterUserDialog = true
                 })
         }
 
@@ -113,7 +145,7 @@ private fun SettingScreen(
 fun SettingScreenPreview() {
     SettingScreen(
         navigateBack = {},
-        signOut = {},
+        logOut = {},
         unRegisterUser = {}
     )
 }

--- a/feature/mypage/src/main/java/com/example/mypage/graph/setting/SettingScreen.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/graph/setting/SettingScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.common.event.TraceEvent
 import com.example.common.util.clickable
 import com.example.designsystem.R
 import com.example.designsystem.component.CheckCancelDialog
@@ -44,14 +45,21 @@ internal fun SettingRoute(
         viewModel.eventChannel.collect { event ->
             when (event) {
                 is SettingEvent.NavigateBack -> navigateBack()
-                is SettingEvent.NavigateToLogin -> navigateToLogin()
+                is SettingEvent.LogoutSuccess -> navigateToLogin()
+                is SettingEvent.LogoutFailure -> {
+                    viewModel.eventHelper.sendEvent(TraceEvent.ShowSnackBar("로그아웃에 실패했습니다."))
+                }
+                is SettingEvent.UnRegisterUserSuccess -> navigateToLogin()
+                is SettingEvent.UnRegisterUserFailure -> {
+                    viewModel.eventHelper.sendEvent(TraceEvent.ShowSnackBar("회원 탈퇴에 실패했습니다."))
+                }
             }
         }
     }
 
     SettingScreen(
         navigateBack = navigateBack,
-        logOut = viewModel::logOut,
+        logout = viewModel::logout,
         unRegisterUser = viewModel::unRegisterUser
     )
 }
@@ -59,19 +67,19 @@ internal fun SettingRoute(
 @Composable
 private fun SettingScreen(
     navigateBack: () -> Unit,
-    logOut: () -> Unit,
+    logout: () -> Unit,
     unRegisterUser: () -> Unit
 ) {
-    var showLogOutDialog by remember { mutableStateOf(false) }
+    var showLogoutDialog by remember { mutableStateOf(false) }
     var showUnRegisterUserDialog by remember { mutableStateOf(false) }
 
-    if (showLogOutDialog) {
+    if (showLogoutDialog) {
         CheckCancelDialog(
             onCheck = {
-                logOut()
-                showLogOutDialog = false
+                logout()
+                showLogoutDialog = false
             },
-            onDismiss = { showLogOutDialog = false },
+            onDismiss = { showLogoutDialog = false },
             dialogText = "정말 로그아웃 하시겠습니까?"
         )
     }
@@ -97,13 +105,13 @@ private fun SettingScreen(
                 .padding(top = 80.dp, start = 30.dp, end = 20.dp)
         ) {
             Text("로그아웃", style = TraceTheme.typography.bodyMR.copy(fontSize = 20.sp, lineHeight = 24.sp), modifier = Modifier.clickable {
-                showLogOutDialog = true
+                showLogoutDialog = true
             })
 
             Spacer(Modifier.height(17.dp))
 
             Text(
-                "회원 탈퇴",
+                "회원탈퇴",
                 style = TraceTheme.typography.bodyMR.copy(fontSize = 20.sp, lineHeight = 24.sp),
                 color = Red,
                 modifier = Modifier.clickable {
@@ -145,7 +153,7 @@ private fun SettingScreen(
 fun SettingScreenPreview() {
     SettingScreen(
         navigateBack = {},
-        logOut = {},
+        logout = {},
         unRegisterUser = {}
     )
 }

--- a/feature/mypage/src/main/java/com/example/mypage/graph/setting/SettingScreen.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/graph/setting/SettingScreen.kt
@@ -49,8 +49,8 @@ internal fun SettingRoute(
                 is SettingEvent.LogoutFailure -> {
                     viewModel.eventHelper.sendEvent(TraceEvent.ShowSnackBar("로그아웃에 실패했습니다."))
                 }
-                is SettingEvent.UnRegisterUserSuccess -> navigateToLogin()
-                is SettingEvent.UnRegisterUserFailure -> {
+                is SettingEvent.UnregisterUserSuccess -> navigateToLogin()
+                is SettingEvent.UnregisterUserFailure -> {
                     viewModel.eventHelper.sendEvent(TraceEvent.ShowSnackBar("회원 탈퇴에 실패했습니다."))
                 }
             }
@@ -60,7 +60,7 @@ internal fun SettingRoute(
     SettingScreen(
         navigateBack = navigateBack,
         logout = viewModel::logout,
-        unRegisterUser = viewModel::unRegisterUser
+        unregisterUser = viewModel::unregisterUser
     )
 }
 
@@ -68,7 +68,7 @@ internal fun SettingRoute(
 private fun SettingScreen(
     navigateBack: () -> Unit,
     logout: () -> Unit,
-    unRegisterUser: () -> Unit
+    unregisterUser: () -> Unit
 ) {
     var showLogoutDialog by remember { mutableStateOf(false) }
     var showUnRegisterUserDialog by remember { mutableStateOf(false) }
@@ -87,7 +87,7 @@ private fun SettingScreen(
     if (showUnRegisterUserDialog) {
         CheckCancelDialog(
             onCheck = {
-                unRegisterUser()
+                unregisterUser()
                 showUnRegisterUserDialog = false
             },
             onDismiss = { showUnRegisterUserDialog = false },
@@ -154,6 +154,6 @@ fun SettingScreenPreview() {
     SettingScreen(
         navigateBack = {},
         logout = {},
-        unRegisterUser = {}
+        unregisterUser = {}
     )
 }

--- a/feature/mypage/src/main/java/com/example/mypage/graph/setting/SettingViewModel.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/graph/setting/SettingViewModel.kt
@@ -15,11 +15,11 @@ class SettingViewModel @Inject constructor(
     private val _eventChannel = Channel<SettingEvent>()
     val eventChannel = _eventChannel.receiveAsFlow()
 
-    fun signOut() {
+    fun logOut() {
 
     }
 
-     fun UnRegisterUser() {
+     fun unRegisterUser() {
 
     }
 

--- a/feature/mypage/src/main/java/com/example/mypage/graph/setting/SettingViewModel.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/graph/setting/SettingViewModel.kt
@@ -1,30 +1,45 @@
 package com.example.mypage.graph.setting
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.common.event.EventHelper
 import com.example.domain.repository.AuthRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 
 @HiltViewModel
 class SettingViewModel @Inject constructor(
-    private val authRepository: AuthRepository
+    private val authRepository: AuthRepository,
+    val eventHelper: EventHelper,
 ) : ViewModel() {
     private val _eventChannel = Channel<SettingEvent>()
     val eventChannel = _eventChannel.receiveAsFlow()
 
-    fun logOut() {
-
+    fun logout() = viewModelScope.launch {
+        authRepository.logOut().onSuccess {
+            _eventChannel.send(SettingEvent.LogoutSuccess)
+        }.onFailure {
+            _eventChannel.send(SettingEvent.LogoutFailure)
+        }
     }
 
-     fun unRegisterUser() {
-
+    fun unRegisterUser() = viewModelScope.launch {
+        authRepository.unRegisterUser().onSuccess {
+            _eventChannel.send(SettingEvent.UnRegisterUserSuccess)
+        }.onFailure {
+            _eventChannel.send(SettingEvent.UnRegisterUserFailure)
+        }
     }
 
     sealed class SettingEvent {
         data object NavigateBack : SettingEvent()
-        data object NavigateToLogin : SettingEvent()
+        data object LogoutSuccess : SettingEvent()
+        data object LogoutFailure : SettingEvent()
+        data object UnRegisterUserSuccess : SettingEvent()
+        data object UnRegisterUserFailure : SettingEvent()
     }
 }

--- a/feature/mypage/src/main/java/com/example/mypage/graph/setting/SettingViewModel.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/graph/setting/SettingViewModel.kt
@@ -27,11 +27,11 @@ class SettingViewModel @Inject constructor(
         }
     }
 
-    fun unRegisterUser() = viewModelScope.launch {
-        authRepository.unRegisterUser().onSuccess {
-            _eventChannel.send(SettingEvent.UnRegisterUserSuccess)
+    fun unregisterUser() = viewModelScope.launch {
+        authRepository.unregisterUser().onSuccess {
+            _eventChannel.send(SettingEvent.UnregisterUserSuccess)
         }.onFailure {
-            _eventChannel.send(SettingEvent.UnRegisterUserFailure)
+            _eventChannel.send(SettingEvent.UnregisterUserFailure)
         }
     }
 
@@ -39,7 +39,7 @@ class SettingViewModel @Inject constructor(
         data object NavigateBack : SettingEvent()
         data object LogoutSuccess : SettingEvent()
         data object LogoutFailure : SettingEvent()
-        data object UnRegisterUserSuccess : SettingEvent()
-        data object UnRegisterUserFailure : SettingEvent()
+        data object UnregisterUserSuccess : SettingEvent()
+        data object UnregisterUserFailure : SettingEvent()
     }
 }


### PR DESCRIPTION
### 🚀 변경 사항 🚀
- 로그아웃 API
- 회원탈퇴 API

### 📸 스크린샷

### 📖 배운 것

### 📝 참고사항
- 현재 회원탈퇴 API에서 사용자가 이미 작성한 글 또는 댓글이 있으면 DB 참조 무결성 위반으로 응답이 500에러로 온다. 백엔드 측에서 수정해주기로 했고 API 연동 로직은 문제 없으므로 우선 병합한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added user logout and account deletion (unregister) options in the settings screen, including confirmation dialogs for both actions.
  - Users now receive feedback via notifications on the outcome of logout and account deletion attempts.

- **Improvements**
  - Updated button labels and event handling for consistency and clarity in the settings screen.
  - Enhanced reliability and responsiveness of logout and account deletion actions through improved asynchronous handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->