### PR TITLE
[Feature] 감정표현 토글 API 연동

### DIFF
--- a/core/common/src/main/java/com/example/common/util/IntUtil.kt
+++ b/core/common/src/main/java/com/example/common/util/IntUtil.kt
@@ -1,5 +1,8 @@
 package com.example.common.util
 
+import android.annotation.SuppressLint
+
+@SuppressLint("DefaultLocale")
 fun Int.formatCount(): String {
     return when {
         this >= 10_000 -> {

--- a/core/common/src/main/java/com/example/common/util/IntUtil.kt
+++ b/core/common/src/main/java/com/example/common/util/IntUtil.kt
@@ -1,0 +1,13 @@
+package com.example.common.util
+
+fun Int.formatCount(): String {
+    return when {
+        this >= 10_000 -> {
+            val value = this / 10_000.0
+            String.format("%.1f만", value)
+        }
+        else -> {
+            String.format("%,d", this)
+        }
+    }
+}

--- a/core/data/src/main/java/com/example/data/repository/PostRepositoryImpl.kt
+++ b/core/data/src/main/java/com/example/data/repository/PostRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.example.data.repository
 
 import com.example.common.util.suspendRunCatching
 import com.example.data.image.ImageResizer
+import com.example.domain.model.post.Emotion
 import com.example.domain.model.post.EmotionCount
 import com.example.domain.model.post.PostDetail
 import com.example.domain.model.post.PostType
@@ -70,6 +71,10 @@ class PostRepositoryImpl @Inject constructor(
 
     override suspend fun deletePost(postId: Int): Result<Unit> = suspendRunCatching {
         postDataSource.deletePost(postId)
+    }
+
+    override suspend fun toggleEmotion(postId: Int, emotionType: Emotion): Result<Unit> = suspendRunCatching {
+            postDataSource.toggleEmotion(postId, emotionType)
     }
 
 }

--- a/core/data/src/main/java/com/example/data/repository/PostRepositoryImpl.kt
+++ b/core/data/src/main/java/com/example/data/repository/PostRepositoryImpl.kt
@@ -73,8 +73,11 @@ class PostRepositoryImpl @Inject constructor(
         postDataSource.deletePost(postId)
     }
 
-    override suspend fun toggleEmotion(postId: Int, emotionType: Emotion): Result<Unit> = suspendRunCatching {
-            postDataSource.toggleEmotion(postId, emotionType)
-    }
+    override suspend fun toggleEmotion(postId: Int, emotionType: Emotion): Result<Boolean> =
+        suspendRunCatching {
+            val response = postDataSource.toggleEmotion(postId, emotionType).getOrThrow()
+
+            response.isAdded
+        }
 
 }

--- a/core/designsystem/src/main/java/com/example/designsystem/theme/Color.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/theme/Color.kt
@@ -31,6 +31,7 @@ val TextHint = Color(0xFF88887F)
 val DarkGray = Color(0xFF747070)
 val WarmGray = Color(0xFF838080)
 val LightGray = Color(0xFF81817A)
+val EmotionLabel = Color(0xFF636060)
 val GrayLine = Color(0xFFE0E0E0)
 
 val ImagePlaceHolder = Color(0xFFE7E7E7)

--- a/core/domain/src/main/java/com/example/domain/model/post/Emotion.kt
+++ b/core/domain/src/main/java/com/example/domain/model/post/Emotion.kt
@@ -3,7 +3,7 @@ package com.example.domain.model.post
 enum class Emotion(val label: String) {
     HeartWarming("따뜻해요"),
     Likeable("좋아요"),
-    Touching("감동적이에요"),
+    Touching("감동이에요"),
     Impressive("멋져요"),
     Grateful("고마워요")
 }

--- a/core/domain/src/main/java/com/example/domain/repository/PostRepository.kt
+++ b/core/domain/src/main/java/com/example/domain/repository/PostRepository.kt
@@ -1,5 +1,6 @@
 package com.example.domain.repository
 
+import com.example.domain.model.post.Emotion
 import com.example.domain.model.post.PostDetail
 import com.example.domain.model.post.WritePostType
 
@@ -21,4 +22,6 @@ interface PostRepository {
     ): Result<Int>
 
     suspend fun deletePost(postId: Int): Result<Unit>
+
+    suspend fun toggleEmotion(postId : Int, emotionType : Emotion) : Result<Unit>
 }

--- a/core/domain/src/main/java/com/example/domain/repository/PostRepository.kt
+++ b/core/domain/src/main/java/com/example/domain/repository/PostRepository.kt
@@ -23,5 +23,5 @@ interface PostRepository {
 
     suspend fun deletePost(postId: Int): Result<Unit>
 
-    suspend fun toggleEmotion(postId : Int, emotionType : Emotion) : Result<Unit>
+    suspend fun toggleEmotion(postId : Int, emotionType : Emotion) : Result<Boolean>
 }

--- a/core/network/src/main/java/com/example/network/api/TraceApi.kt
+++ b/core/network/src/main/java/com/example/network/api/TraceApi.kt
@@ -8,6 +8,8 @@ import com.example.network.model.comment.AddReplyToCommentRequest
 import com.example.network.model.comment.CommentResponse
 import com.example.network.model.post.AddPostResponse
 import com.example.network.model.post.GetPostResponse
+import com.example.network.model.post.ToggleEmotionRequest
+import com.example.network.model.post.ToggleEmotionResponse
 import com.example.network.model.post.UpdatePostRequest
 import com.example.network.model.post.UpdatePostResponse
 import com.example.network.model.token.CheckTokenHealthResponse
@@ -61,6 +63,11 @@ interface TraceApi {
     suspend fun deletePost(
         @Path("id") postId: Int,
     ): Result<Unit>
+
+    @POST("/api/v1/emotion")
+    suspend fun toggleEmotion(
+        @Body toggleEmotionRequest : ToggleEmotionRequest,
+    ) : Result<ToggleEmotionResponse>
 
     @POST("/api/v1/comments/{postId}")
     suspend fun addComment(

--- a/core/network/src/main/java/com/example/network/model/post/ToggleEmotionRequest.kt
+++ b/core/network/src/main/java/com/example/network/model/post/ToggleEmotionRequest.kt
@@ -1,0 +1,9 @@
+package com.example.network.model.post
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ToggleEmotionRequest(
+    val postId : Int,
+    val emotionType: String,
+)

--- a/core/network/src/main/java/com/example/network/model/post/ToggleEmotionResponse.kt
+++ b/core/network/src/main/java/com/example/network/model/post/ToggleEmotionResponse.kt
@@ -1,0 +1,9 @@
+package com.example.network.model.post
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ToggleEmotionResponse(
+    val emotionType : String,
+    val isAdded : Boolean,
+)

--- a/core/network/src/main/java/com/example/network/source/post/PostDataSource.kt
+++ b/core/network/src/main/java/com/example/network/source/post/PostDataSource.kt
@@ -1,9 +1,11 @@
 package com.example.network.source.post
 
 
+import com.example.domain.model.post.Emotion
 import com.example.domain.model.post.WritePostType
 import com.example.network.model.post.AddPostResponse
 import com.example.network.model.post.GetPostResponse
+import com.example.network.model.post.ToggleEmotionResponse
 import com.example.network.model.post.UpdatePostResponse
 import java.io.InputStream
 
@@ -23,4 +25,9 @@ interface PostDataSource {
     suspend fun deletePost(
         postId : Int,
     ) : Result<Unit>
+
+    suspend fun toggleEmotion(
+        postId : Int,
+        emotionType : Emotion
+    ) : Result<ToggleEmotionResponse>
 }

--- a/core/network/src/main/java/com/example/network/source/post/PostDataSourceImpl.kt
+++ b/core/network/src/main/java/com/example/network/source/post/PostDataSourceImpl.kt
@@ -2,11 +2,14 @@ package com.example.network.source.post
 
 import android.os.Build
 import android.util.Log
+import com.example.domain.model.post.Emotion
 import com.example.domain.model.post.WritePostType
 import com.example.network.api.TraceApi
 import com.example.network.model.post.AddPostRequest
 import com.example.network.model.post.AddPostResponse
 import com.example.network.model.post.GetPostResponse
+import com.example.network.model.post.ToggleEmotionRequest
+import com.example.network.model.post.ToggleEmotionResponse
 import com.example.network.model.post.UpdatePostRequest
 import com.example.network.model.post.UpdatePostResponse
 import kotlinx.serialization.json.Json
@@ -84,6 +87,16 @@ class PostDataSourceImpl @Inject constructor(
 
     override suspend fun deletePost(postId: Int): Result<Unit> = traceApi.deletePost(postId)
 
+    override suspend fun toggleEmotion(
+        postId: Int,
+        emotionType: Emotion
+    ): Result<ToggleEmotionResponse> =
+        traceApi.toggleEmotion(
+            toggleEmotionRequest = ToggleEmotionRequest(
+                postId = postId,
+                emotionType = emotionType.name
+            )
+        )
 
     companion object {
         private const val WEBP_MEDIA_TYPE = "image/webp"

--- a/feature/home/src/main/java/com/example/home/graph/post/PostScreen.kt
+++ b/feature/home/src/main/java/com/example/home/graph/post/PostScreen.kt
@@ -51,6 +51,7 @@ import coil3.request.ImageRequest
 import coil3.request.crossfade
 import com.example.common.event.TraceEvent
 import com.example.common.util.clickable
+import com.example.common.util.formatCount
 import com.example.designsystem.R
 import com.example.designsystem.theme.Background
 import com.example.designsystem.theme.Black
@@ -110,6 +111,7 @@ internal fun PostRoute(
         onAddComment = viewModel::addComment,
         onDeletePost = viewModel::deletePost,
         onReportPost = viewModel::reportPost,
+        toggleEmotion = viewModel::toggleEmotion,
         onDeleteComment = viewModel::deleteComment,
         onReplyComment = viewModel::replyComment,
         onReplyTargetIdChange = viewModel::setReplyTargetId,
@@ -129,6 +131,7 @@ private fun PostScreen(
     isCommentLoading: Boolean,
     onDeletePost: () -> Unit,
     onReportPost: () -> Unit,
+    toggleEmotion : (Emotion) -> Unit,
     onAddComment: () -> Unit,
     onCommentInputChange: (String) -> Unit,
     onDeleteComment: (Int) -> Unit,
@@ -283,7 +286,7 @@ private fun PostScreen(
 
                         Column(
                             modifier = Modifier.clickable(isRipple = true) {
-
+                                toggleEmotion(emotion)
                             },
                             horizontalAlignment = Alignment.CenterHorizontally
                         ) {
@@ -303,7 +306,7 @@ private fun PostScreen(
 
                             Spacer(Modifier.height(5.dp))
 
-                            Text(emotionCount.toString(), style = TraceTheme.typography.bodySSB)
+                            Text(emotionCount.formatCount(), style = TraceTheme.typography.bodySSB)
                         }
                     }
                 }
@@ -534,6 +537,7 @@ fun PostScreenPreview() {
         onReportPost = {},
         onReplyTargetIdChange = {},
         clearReplayTargetId = {},
+        toggleEmotion = {},
         replyTargetId = null
     )
 }

--- a/feature/home/src/main/java/com/example/home/graph/post/PostScreen.kt
+++ b/feature/home/src/main/java/com/example/home/graph/post/PostScreen.kt
@@ -3,6 +3,7 @@ package com.example.home.graph.post
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -19,6 +20,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -52,12 +55,14 @@ import com.example.designsystem.R
 import com.example.designsystem.theme.Background
 import com.example.designsystem.theme.Black
 import com.example.designsystem.theme.DarkGray
+import com.example.designsystem.theme.EmotionLabel
 import com.example.designsystem.theme.GrayLine
 import com.example.designsystem.theme.PrimaryActive
 import com.example.designsystem.theme.PrimaryDefault
 import com.example.designsystem.theme.TraceTheme
 import com.example.designsystem.theme.WarmGray
 import com.example.designsystem.theme.White
+import com.example.domain.model.post.Emotion
 import com.example.domain.model.post.PostDetail
 import com.example.domain.model.post.PostType
 import com.example.home.graph.post.PostViewModel.PostEvent
@@ -262,6 +267,48 @@ private fun PostScreen(
                 )
 
                 Spacer(Modifier.height(50.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Emotion.entries.forEach { emotion ->
+                        val emotionCount = when(emotion) {
+                            Emotion.HeartWarming -> postDetail.emotionCount.heartWarmingCount
+                            Emotion.Likeable -> postDetail.emotionCount.likeableCount
+                            Emotion.Touching -> postDetail.emotionCount.touchingCount
+                            Emotion.Impressive -> postDetail.emotionCount.impressiveCount
+                            Emotion.Grateful -> postDetail.emotionCount.gratefulCount
+                        }
+
+                        Column(
+                            modifier = Modifier.clickable(isRipple = true) {
+
+                            },
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            Text(
+                                emotion.label,
+                                style = TraceTheme.typography.bodySR,
+                                color = EmotionLabel
+                            )
+
+                            Spacer(Modifier.height(3.dp))
+
+                            Image(
+                                imageVector = Icons.Default.Favorite,
+                                contentDescription = emotion.label,
+                                modifier = Modifier.size(20.dp)
+                            )
+
+                            Spacer(Modifier.height(5.dp))
+
+                            Text(emotionCount.toString(), style = TraceTheme.typography.bodySSB)
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(8.dp))
 
                 Spacer(
                     modifier = Modifier

--- a/feature/home/src/main/java/com/example/home/graph/post/PostScreen.kt
+++ b/feature/home/src/main/java/com/example/home/graph/post/PostScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -131,7 +132,7 @@ private fun PostScreen(
     isCommentLoading: Boolean,
     onDeletePost: () -> Unit,
     onReportPost: () -> Unit,
-    toggleEmotion : (Emotion) -> Unit,
+    toggleEmotion: (Emotion) -> Unit,
     onAddComment: () -> Unit,
     onCommentInputChange: (String) -> Unit,
     onDeleteComment: (Int) -> Unit,
@@ -276,7 +277,7 @@ private fun PostScreen(
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
                     Emotion.entries.forEach { emotion ->
-                        val emotionCount = when(emotion) {
+                        val emotionCount = when (emotion) {
                             Emotion.HeartWarming -> postDetail.emotionCount.heartWarmingCount
                             Emotion.Likeable -> postDetail.emotionCount.likeableCount
                             Emotion.Touching -> postDetail.emotionCount.touchingCount
@@ -285,9 +286,6 @@ private fun PostScreen(
                         }
 
                         Column(
-                            modifier = Modifier.clickable(isRipple = true) {
-                                toggleEmotion(emotion)
-                            },
                             horizontalAlignment = Alignment.CenterHorizontally
                         ) {
                             Text(
@@ -298,17 +296,26 @@ private fun PostScreen(
 
                             Spacer(Modifier.height(3.dp))
 
-                            Image(
-                                imageVector = Icons.Default.Favorite,
-                                contentDescription = emotion.label,
-                                modifier = Modifier.size(20.dp)
-                            )
+                            IconButton(onClick = {
+                                toggleEmotion(emotion)
+                            }, modifier = Modifier.then(Modifier.size(20.dp))) {
+                                Image(
+                                    imageVector = Icons.Default.Favorite,
+                                    contentDescription = emotion.label,
+                                    modifier = Modifier.size(20.dp)
+                                )
+                            }
 
                             Spacer(Modifier.height(5.dp))
 
-                            Text(emotionCount.formatCount(), style = TraceTheme.typography.bodySSB)
+                            Text(
+                                emotionCount.formatCount(),
+                                style = TraceTheme.typography.bodySSB
+                            )
                         }
                     }
+
+
                 }
 
                 Spacer(Modifier.height(8.dp))

--- a/feature/home/src/main/java/com/example/home/graph/post/PostViewModel.kt
+++ b/feature/home/src/main/java/com/example/home/graph/post/PostViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.example.common.event.EventHelper
 import com.example.common.event.TraceEvent
 import com.example.domain.model.post.Comment
+import com.example.domain.model.post.Emotion
 import com.example.domain.model.post.EmotionCount
 import com.example.domain.model.post.PostDetail
 import com.example.domain.model.post.PostType
@@ -82,6 +83,12 @@ class PostViewModel @Inject constructor(
         }
     }
 
+    fun toggleEmotion(emotion: Emotion) = viewModelScope.launch {
+        postRepository.toggleEmotion(postId = postId, emotionType = emotion).onSuccess {
+
+        }
+    }
+
     fun addComment() = viewModelScope.launch {
         if (_commentInput.value.isEmpty()) {
             eventHelper.sendEvent(TraceEvent.ShowSnackBar("내용을 입력해주세요."))
@@ -105,7 +112,7 @@ class PostViewModel @Inject constructor(
 
     }
 
-    fun replyComment(onSuccess : (Int) -> Unit) =
+    fun replyComment(onSuccess: (Int) -> Unit) =
         viewModelScope.launch {
             val parentId = _replyTargetId.value ?: return@launch
 

--- a/feature/home/src/main/java/com/example/home/graph/post/PostViewModel.kt
+++ b/feature/home/src/main/java/com/example/home/graph/post/PostViewModel.kt
@@ -84,8 +84,32 @@ class PostViewModel @Inject constructor(
     }
 
     fun toggleEmotion(emotion: Emotion) = viewModelScope.launch {
-        postRepository.toggleEmotion(postId = postId, emotionType = emotion).onSuccess {
+        postRepository.toggleEmotion(postId = postId, emotionType = emotion).onSuccess { isAdded ->
+            val current = _postDetail.value
 
+            val updatedEmotionCount = when (emotion) {
+                Emotion.HeartWarming -> current.emotionCount.copy(
+                    heartWarmingCount = current.emotionCount.heartWarmingCount + if (isAdded) 1 else -1
+                )
+
+                Emotion.Likeable -> current.emotionCount.copy(
+                    likeableCount = current.emotionCount.likeableCount + if (isAdded) 1 else -1
+                )
+
+                Emotion.Touching -> current.emotionCount.copy(
+                    touchingCount = current.emotionCount.touchingCount + if (isAdded) 1 else -1
+                )
+
+                Emotion.Impressive -> current.emotionCount.copy(
+                    impressiveCount = current.emotionCount.impressiveCount + if (isAdded) 1 else -1
+                )
+
+                Emotion.Grateful -> current.emotionCount.copy(
+                    gratefulCount = current.emotionCount.gratefulCount + if (isAdded) 1 else -1
+                )
+            }
+
+            _postDetail.value = current.copy(emotionCount = updatedEmotionCount)
         }
     }
 


### PR DESCRIPTION
### 🚀 변경 사항 🚀
- 감정표현 토글 API
- 게시글에 감정표현 UI 추가(임시)

### 📸 스크린샷

### 📖 배운 것

### 📝 참고사항
- 현재 게시글 조회에 사용자가 어떤 감정표현을 눌렀는지 응답을 받지 않아서 백엔드에서 추가할 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability for users to react to posts with various emotions and toggle their reactions directly from the post detail screen.
  - Emotion counts are now displayed and formatted for readability, including support for large numbers.
- **Enhancements**
  - Updated the label for the "Touching" emotion for improved clarity.
  - Introduced a new color for emotion labels to enhance visual distinction.
- **Bug Fixes**
  - Minor formatting correction in the comment reply function signature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->