### PR TITLE
[Feature] 회원정보 조회 API 연동

### DIFF
--- a/core/data/src/main/java/com/example/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/example/data/repository/AuthRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.example.data.repository
 import com.example.common.util.suspendRunCatching
 import com.example.data.image.ImageResizer
 import com.example.datastore.datasource.token.LocalTokenDataSource
+import com.example.datastore.datasource.user.LocalUserDataSource
 import com.example.domain.model.auth.User
 import com.example.domain.model.auth.UserRole
 import com.example.domain.repository.AuthRepository
@@ -14,7 +15,8 @@ import javax.inject.Inject
 class AuthRepositoryImpl @Inject constructor(
     private val authDataSource: AuthDataSource,
     private val localTokenDataSource: LocalTokenDataSource,
-    private val imageResizer: ImageResizer
+    private val localUserDataSource: LocalUserDataSource,
+    private val imageResizer: ImageResizer,
 ) : AuthRepository {
     override suspend fun loginKakao(idToken: String): Result<User> = suspendRunCatching {
         val response = authDataSource.loginKakao(idToken).getOrThrow()
@@ -79,7 +81,12 @@ class AuthRepositoryImpl @Inject constructor(
                 localTokenDataSource.clearToken()
             }
 
+            val userInfoJob = launch {
+                localUserDataSource.clearUserInfo()
+            }
+
             clearTokenJob.join()
+            userInfoJob.join()
         }
 
     }
@@ -92,7 +99,12 @@ class AuthRepositoryImpl @Inject constructor(
                 localTokenDataSource.clearToken()
             }
 
+            val userInfoJob = launch {
+                localUserDataSource.clearUserInfo()
+            }
+
             clearTokenJob.join()
+            userInfoJob.join()
         }
     }
 }

--- a/core/data/src/main/java/com/example/data/repository/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/example/data/repository/UserRepositoryImpl.kt
@@ -2,17 +2,20 @@ package com.example.data.repository
 
 import com.example.common.util.suspendRunCatching
 import com.example.datastore.datasource.token.LocalTokenDataSource
+import com.example.datastore.datasource.user.LocalUserDataSource
 import com.example.domain.repository.UserRepository
 import com.example.domain.user.UserInfo
 import com.example.network.source.auth.AuthDataSource
 import com.example.network.source.user.UserDataSource
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import javax.inject.Inject
 
 class UserRepositoryImpl @Inject constructor(
     private val localTokenDataSource: LocalTokenDataSource,
     private val authDataSource: AuthDataSource,
     private val userDataSource: UserDataSource,
+    private val localUserDataSource: LocalUserDataSource,
 ) : UserRepository {
     override suspend fun checkTokenHealth(): Result<Unit> = suspendRunCatching {
         val token = localTokenDataSource.accessToken.first()
@@ -21,14 +24,21 @@ class UserRepositoryImpl @Inject constructor(
         authDataSource.checkTokenHealth(token)
     }
 
+    override suspend fun getUserInfo(): Result<UserInfo> = suspendRunCatching {
+        val userInfo = localUserDataSource.userInfo.firstOrNull()
+        userInfo ?: loadUserInfo().getOrThrow()
+    }
+
     override suspend fun loadUserInfo(): Result<UserInfo> = suspendRunCatching {
         val response = userDataSource.loadUserInfo().getOrThrow()
-
-        UserInfo(
+        val userInfo = UserInfo(
             name = response.nickname,
             profileImageUrl = response.profileImageUrl,
             goodDeedScore = response.goodDeedScore,
             goodDeedMarkCount = response.goodDeedMarkCount,
         )
+
+        localUserDataSource.setUserInfo(userInfo)
+        userInfo
     }
 }

--- a/core/data/src/main/java/com/example/data/repository/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/example/data/repository/UserRepositoryImpl.kt
@@ -3,18 +3,32 @@ package com.example.data.repository
 import com.example.common.util.suspendRunCatching
 import com.example.datastore.datasource.token.LocalTokenDataSource
 import com.example.domain.repository.UserRepository
+import com.example.domain.user.UserInfo
 import com.example.network.source.auth.AuthDataSource
+import com.example.network.source.user.UserDataSource
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
 class UserRepositoryImpl @Inject constructor(
     private val localTokenDataSource: LocalTokenDataSource,
-    private val authDataSource: AuthDataSource
+    private val authDataSource: AuthDataSource,
+    private val userDataSource: UserDataSource,
 ) : UserRepository {
     override suspend fun checkTokenHealth(): Result<Unit> = suspendRunCatching {
         val token = localTokenDataSource.accessToken.first()
         if (token.isEmpty()) return@suspendRunCatching
 
         authDataSource.checkTokenHealth(token)
+    }
+
+    override suspend fun loadUserInfo(): Result<UserInfo> = suspendRunCatching {
+        val response = userDataSource.loadUserInfo().getOrThrow()
+
+        UserInfo(
+            name = response.nickname,
+            profileImageUrl = response.profileImageUrl,
+            goodDeedScore = response.goodDeedScore,
+            goodDeedMarkCount = response.goodDeedMarkCount,
+        )
     }
 }

--- a/core/datastore/build.gradle.kts
+++ b/core/datastore/build.gradle.kts
@@ -11,4 +11,5 @@ dependencies {
     implementation(projects.core.domain)
 
     implementation(libs.androidx.datastore)
+    implementation(libs.gson)
 }

--- a/core/datastore/src/main/java/com/example/datastore/datasource/user/LocalUserDataSource.kt
+++ b/core/datastore/src/main/java/com/example/datastore/datasource/user/LocalUserDataSource.kt
@@ -6,5 +6,5 @@ import kotlinx.coroutines.flow.Flow
 interface LocalUserDataSource {
     val userInfo : Flow<UserInfo?>
     suspend fun setUserInfo(userInfo: UserInfo)
-    suspend fun clearUserInfo(userInfo: UserInfo)
+    suspend fun clearUserInfo()
 }

--- a/core/datastore/src/main/java/com/example/datastore/datasource/user/LocalUserDataSource.kt
+++ b/core/datastore/src/main/java/com/example/datastore/datasource/user/LocalUserDataSource.kt
@@ -1,0 +1,10 @@
+package com.example.datastore.datasource.user
+
+import com.example.domain.user.UserInfo
+import kotlinx.coroutines.flow.Flow
+
+interface LocalUserDataSource {
+    val userInfo : Flow<UserInfo?>
+    suspend fun setUserInfo(userInfo: UserInfo)
+    suspend fun clearUserInfo(userInfo: UserInfo)
+}

--- a/core/datastore/src/main/java/com/example/datastore/datasource/user/LocalUserDataSourceImpl.kt
+++ b/core/datastore/src/main/java/com/example/datastore/datasource/user/LocalUserDataSourceImpl.kt
@@ -1,0 +1,49 @@
+package com.example.datastore.datasource.user
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.IOException
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.example.domain.user.UserInfo
+import com.google.gson.Gson
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Named
+
+class LocalUserDataSourceImpl @Inject constructor(
+    @Named("user") private val datastore : DataStore<Preferences>,
+    private val gson : Gson,
+) : LocalUserDataSource {
+    override val userInfo: Flow<UserInfo?> = datastore.data
+        .catch { exception ->
+            if (exception is IOException)
+                emit(emptyPreferences())
+            else
+                throw exception
+        }.map { preferences ->
+            val userInfo = preferences[USER_INFO] ?: ""
+           if(userInfo.isNotEmpty()) gson.fromJson(userInfo, UserInfo::class.java)
+            else null
+        }
+
+    override suspend fun setUserInfo(userInfo: UserInfo) {
+        val jsonString = gson.toJson(userInfo)
+        datastore.edit { preferences ->
+            preferences[USER_INFO] = jsonString
+        }
+    }
+
+    override suspend fun clearUserInfo(userInfo: UserInfo) {
+        datastore.edit { preferences ->
+            preferences.remove(USER_INFO)
+        }
+    }
+    companion object {
+        private val USER_INFO = stringPreferencesKey("USER_INFO")
+    }
+
+}

--- a/core/datastore/src/main/java/com/example/datastore/datasource/user/LocalUserDataSourceImpl.kt
+++ b/core/datastore/src/main/java/com/example/datastore/datasource/user/LocalUserDataSourceImpl.kt
@@ -37,7 +37,7 @@ class LocalUserDataSourceImpl @Inject constructor(
         }
     }
 
-    override suspend fun clearUserInfo(userInfo: UserInfo) {
+    override suspend fun clearUserInfo() {
         datastore.edit { preferences ->
             preferences.remove(USER_INFO)
         }

--- a/core/datastore/src/main/java/com/example/datastore/datasource/user/LocalUserDataSourceImpl.kt
+++ b/core/datastore/src/main/java/com/example/datastore/datasource/user/LocalUserDataSourceImpl.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
+import com.example.datastore.util.fromJsonOrNull
 import com.example.domain.user.UserInfo
 import com.google.gson.Gson
 import kotlinx.coroutines.flow.Flow
@@ -26,8 +27,7 @@ class LocalUserDataSourceImpl @Inject constructor(
                 throw exception
         }.map { preferences ->
             val userInfo = preferences[USER_INFO] ?: ""
-           if(userInfo.isNotEmpty()) gson.fromJson(userInfo, UserInfo::class.java)
-            else null
+            gson.fromJsonOrNull(userInfo)
         }
 
     override suspend fun setUserInfo(userInfo: UserInfo) {

--- a/core/datastore/src/main/java/com/example/datastore/di/DataStoreModule.kt
+++ b/core/datastore/src/main/java/com/example/datastore/di/DataStoreModule.kt
@@ -30,7 +30,7 @@ object DataStoreProvidesModule {
     private const val KEYWORD_DATASTORE_NAME = "KEYWORD_PREFERENCES"
     private val Context.keywordDataStore by preferencesDataStore(name = KEYWORD_DATASTORE_NAME)
 
-    private const val USER_DATASTORE_NAME = "KEYWORD_PREFERENCES"
+    private const val USER_DATASTORE_NAME = "USER_PREFERENCES"
     private val Context.userDataStore by preferencesDataStore(name = USER_DATASTORE_NAME)
 
     @Provides

--- a/core/datastore/src/main/java/com/example/datastore/di/DataStoreModule.kt
+++ b/core/datastore/src/main/java/com/example/datastore/di/DataStoreModule.kt
@@ -8,6 +8,10 @@ import com.example.datastore.datasource.keyword.LocalKeywordDataSource
 import com.example.datastore.datasource.keyword.LocalKeywordDataSourceImpl
 import com.example.datastore.datasource.token.LocalTokenDataSource
 import com.example.datastore.datasource.token.LocalTokenDataSourceImpl
+import com.example.datastore.datasource.user.LocalUserDataSource
+import com.example.datastore.datasource.user.LocalUserDataSourceImpl
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -26,6 +30,13 @@ object DataStoreProvidesModule {
     private const val KEYWORD_DATASTORE_NAME = "KEYWORD_PREFERENCES"
     private val Context.keywordDataStore by preferencesDataStore(name = KEYWORD_DATASTORE_NAME)
 
+    private const val USER_DATASTORE_NAME = "KEYWORD_PREFERENCES"
+    private val Context.userDataStore by preferencesDataStore(name = USER_DATASTORE_NAME)
+
+    @Provides
+    @Singleton
+    fun provideGson(): Gson = GsonBuilder().create()
+
     @Provides
     @Singleton
     @Named("token")
@@ -40,6 +51,12 @@ object DataStoreProvidesModule {
         @ApplicationContext context: Context
     ): DataStore<Preferences> = context.keywordDataStore
 
+    @Provides
+    @Singleton
+    @Named("user")
+    fun provideUserDataStore(
+        @ApplicationContext context: Context
+    ): DataStore<Preferences> = context.userDataStore
 }
 
 @Module
@@ -57,4 +74,10 @@ abstract class DatastoreBindsModule {
     abstract fun bindsLocalKeywordDataSource(
         localKeywordDataSourceImpl: LocalKeywordDataSourceImpl,
     ): LocalKeywordDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindsUserDataSource(
+        localUserDataSourceImpl: LocalUserDataSourceImpl,
+    ): LocalUserDataSource
 }

--- a/core/datastore/src/main/java/com/example/datastore/util/DataStoreUtil.kt
+++ b/core/datastore/src/main/java/com/example/datastore/util/DataStoreUtil.kt
@@ -1,0 +1,2 @@
+package com.example.datastore.util
+

--- a/core/datastore/src/main/java/com/example/datastore/util/DataStoreUtil.kt
+++ b/core/datastore/src/main/java/com/example/datastore/util/DataStoreUtil.kt
@@ -1,2 +1,13 @@
 package com.example.datastore.util
 
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+
+inline fun <reified T> Gson.fromJsonOrNull(json: String): T? {
+    return try {
+        val type = object : TypeToken<T>() {}.type
+        fromJson<T>(json, type)
+    } catch (e: Exception) {
+        null
+    }
+}

--- a/core/domain/src/main/java/com/example/domain/repository/UserRepository.kt
+++ b/core/domain/src/main/java/com/example/domain/repository/UserRepository.kt
@@ -1,5 +1,9 @@
 package com.example.domain.repository
 
+import com.example.domain.user.UserInfo
+
 interface UserRepository {
     suspend fun checkTokenHealth() : Result<Unit>
+
+    suspend fun loadUserInfo() : Result<UserInfo>
 }

--- a/core/domain/src/main/java/com/example/domain/repository/UserRepository.kt
+++ b/core/domain/src/main/java/com/example/domain/repository/UserRepository.kt
@@ -4,6 +4,6 @@ import com.example.domain.user.UserInfo
 
 interface UserRepository {
     suspend fun checkTokenHealth() : Result<Unit>
-
+    suspend fun getUserInfo() : Result<UserInfo>
     suspend fun loadUserInfo() : Result<UserInfo>
 }

--- a/core/network/src/main/java/com/example/network/api/TraceApi.kt
+++ b/core/network/src/main/java/com/example/network/api/TraceApi.kt
@@ -13,6 +13,7 @@ import com.example.network.model.post.ToggleEmotionResponse
 import com.example.network.model.post.UpdatePostRequest
 import com.example.network.model.post.UpdatePostResponse
 import com.example.network.model.token.CheckTokenHealthResponse
+import com.example.network.model.user.LoadUserInfoResponse
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import retrofit2.http.Body
@@ -92,4 +93,7 @@ interface TraceApi {
 
     @POST("/api/v1/user/delete")
     suspend fun unregisterUser() : Result<Unit>
+
+    @POST("/api/v1/user")
+    suspend fun loadUserInfo() : Result<LoadUserInfoResponse>
 }

--- a/core/network/src/main/java/com/example/network/api/TraceApi.kt
+++ b/core/network/src/main/java/com/example/network/api/TraceApi.kt
@@ -94,6 +94,6 @@ interface TraceApi {
     @POST("/api/v1/user/delete")
     suspend fun unregisterUser() : Result<Unit>
 
-    @POST("/api/v1/user")
+    @GET("/api/v1/user")
     suspend fun loadUserInfo() : Result<LoadUserInfoResponse>
 }

--- a/core/network/src/main/java/com/example/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/example/network/di/NetworkModule.kt
@@ -6,6 +6,8 @@ import com.example.network.source.comment.CommentDataSource
 import com.example.network.source.comment.CommentDataSourceImpl
 import com.example.network.source.post.PostDataSource
 import com.example.network.source.post.PostDataSourceImpl
+import com.example.network.source.user.UserDataSource
+import com.example.network.source.user.UserDataSourceImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -19,6 +21,10 @@ abstract class NetworkModule {
     @Binds
     @Singleton
     abstract fun bindsAuthDataSource(authDataSourceImpl: AuthDataSourceImpl): AuthDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindsUserDataSource(userDataSourceImpl: UserDataSourceImpl): UserDataSource
 
     @Binds
     @Singleton

--- a/core/network/src/main/java/com/example/network/model/user/LoadUserInfoResponse.kt
+++ b/core/network/src/main/java/com/example/network/model/user/LoadUserInfoResponse.kt
@@ -1,0 +1,11 @@
+package com.example.network.model.user
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class LoadUserInfoResponse(
+    val nickname : String,
+    val profileImageUrl : String,
+    val goodDeedScore : Int = 0,
+    val goodDeedMarkCount : Int = 0,
+)

--- a/core/network/src/main/java/com/example/network/source/user/UserDataSource.kt
+++ b/core/network/src/main/java/com/example/network/source/user/UserDataSource.kt
@@ -1,0 +1,7 @@
+package com.example.network.source.user
+
+import com.example.network.model.user.LoadUserInfoResponse
+
+interface UserDataSource {
+    suspend fun loadUserInfo() : Result<LoadUserInfoResponse>
+}

--- a/core/network/src/main/java/com/example/network/source/user/UserDataSourceImpl.kt
+++ b/core/network/src/main/java/com/example/network/source/user/UserDataSourceImpl.kt
@@ -1,0 +1,11 @@
+package com.example.network.source.user
+
+import com.example.network.api.TraceApi
+import com.example.network.model.user.LoadUserInfoResponse
+import javax.inject.Inject
+
+class UserDataSourceImpl @Inject constructor(
+    private val traceApi: TraceApi,
+) : UserDataSource {
+    override suspend fun loadUserInfo(): Result<LoadUserInfoResponse> = traceApi.loadUserInfo()
+}

--- a/feature/mypage/src/main/java/com/example/mypage/graph/mypage/MyPageViewModel.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/graph/mypage/MyPageViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.example.domain.model.mypage.MyPageTab
 import com.example.domain.model.post.PostFeed
 import com.example.domain.model.post.PostType
+import com.example.domain.repository.UserRepository
 import com.example.domain.user.UserInfo
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
@@ -17,7 +18,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
-
+    private val userRepository: UserRepository,
 ) : ViewModel() {
     private val _eventChannel = Channel<MyPageEvent>()
     val eventChannel = _eventChannel.receiveAsFlow()
@@ -27,7 +28,7 @@ class MyPageViewModel @Inject constructor(
     }
 
     init {
-
+        loadUserInfo()
     }
 
     private val _userInfo = MutableStateFlow(
@@ -49,8 +50,10 @@ class MyPageViewModel @Inject constructor(
     private val _reactedPosts: MutableStateFlow<List<PostFeed>> = MutableStateFlow(fakePostFeeds)
     val reactedPosts = _reactedPosts.asStateFlow()
 
-    private fun setUserInfo(newInfo: UserInfo) {
-        _userInfo.value = newInfo
+    private fun loadUserInfo() = viewModelScope.launch {
+        val userInfo = userRepository.loadUserInfo().onSuccess { userInfo ->
+            _userInfo.value = userInfo
+        }
     }
 
     fun setTabType(tab: MyPageTab) {
@@ -71,7 +74,7 @@ class MyPageViewModel @Inject constructor(
 
     sealed class MyPageEvent {
         data object NavigateToEditProfile : MyPageEvent()
-        data class NavigateToPost(val postId : Int) : MyPageEvent()
+        data class NavigateToPost(val postId: Int) : MyPageEvent()
         data object NavigateToSetting : MyPageEvent()
     }
 }

--- a/feature/mypage/src/main/java/com/example/mypage/graph/mypage/MyPageViewModel.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/graph/mypage/MyPageViewModel.kt
@@ -51,7 +51,7 @@ class MyPageViewModel @Inject constructor(
     val reactedPosts = _reactedPosts.asStateFlow()
 
     private fun loadUserInfo() = viewModelScope.launch {
-        val userInfo = userRepository.loadUserInfo().onSuccess { userInfo ->
+       userRepository.loadUserInfo().onSuccess { userInfo ->
             _userInfo.value = userInfo
         }
     }

--- a/feature/mypage/src/main/java/com/example/mypage/graph/mypage/MyPageViewModel.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/graph/mypage/MyPageViewModel.kt
@@ -28,7 +28,7 @@ class MyPageViewModel @Inject constructor(
     }
 
     init {
-        loadUserInfo()
+        getUserInfo()
     }
 
     private val _userInfo = MutableStateFlow(
@@ -50,8 +50,8 @@ class MyPageViewModel @Inject constructor(
     private val _reactedPosts: MutableStateFlow<List<PostFeed>> = MutableStateFlow(fakePostFeeds)
     val reactedPosts = _reactedPosts.asStateFlow()
 
-    private fun loadUserInfo() = viewModelScope.launch {
-       userRepository.loadUserInfo().onSuccess { userInfo ->
+    private fun getUserInfo() = viewModelScope.launch {
+       userRepository.getUserInfo().onSuccess { userInfo ->
             _userInfo.value = userInfo
         }
     }

--- a/feature/mypage/src/main/java/com/example/mypage/graph/updateprofile/UpdateProfileViewModel.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/graph/updateprofile/UpdateProfileViewModel.kt
@@ -1,16 +1,19 @@
 package com.example.mypage.graph.updateprofile
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.domain.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class UpdateProfileViewModel @Inject constructor(
-
+    private val userRepository: UserRepository
 ) : ViewModel() {
     private val _eventChannel = Channel<UpdateProfileEvent>()
     val eventChannel = _eventChannel.receiveAsFlow()
@@ -25,7 +28,14 @@ class UpdateProfileViewModel @Inject constructor(
     val profileImage = _profileImageUrl.asStateFlow()
 
     init {
+        loadUserInfo()
+    }
 
+    private fun loadUserInfo() = viewModelScope.launch {
+        userRepository.loadUserInfo().onSuccess { userInfo ->
+            setName(userInfo.name)
+            setProfileImageUrl(userInfo.profileImageUrl)
+        }
     }
 
     fun setName(name: String) {

--- a/feature/mypage/src/main/java/com/example/mypage/graph/updateprofile/UpdateProfileViewModel.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/graph/updateprofile/UpdateProfileViewModel.kt
@@ -32,7 +32,7 @@ class UpdateProfileViewModel @Inject constructor(
     }
 
     private fun getUserInfo() = viewModelScope.launch {
-        userRepository.getUserInfo().onSuccess { userInfo ->
+        userRepository.loadUserInfo().onSuccess { userInfo ->
             setName(userInfo.name)
             setProfileImageUrl(userInfo.profileImageUrl)
         }

--- a/feature/mypage/src/main/java/com/example/mypage/graph/updateprofile/UpdateProfileViewModel.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/graph/updateprofile/UpdateProfileViewModel.kt
@@ -28,11 +28,11 @@ class UpdateProfileViewModel @Inject constructor(
     val profileImage = _profileImageUrl.asStateFlow()
 
     init {
-        loadUserInfo()
+        getUserInfo()
     }
 
-    private fun loadUserInfo() = viewModelScope.launch {
-        userRepository.loadUserInfo().onSuccess { userInfo ->
+    private fun getUserInfo() = viewModelScope.launch {
+        userRepository.getUserInfo().onSuccess { userInfo ->
             setName(userInfo.name)
             setProfileImageUrl(userInfo.profileImageUrl)
         }


### PR DESCRIPTION
### 🚀 변경 사항 🚀
- 회원 정보 조회 API
- 마이페이지 연결
- 프로필 편집 화면 연결
- 회원 정보 로컬에 저장

### 📸 스크린샷

### 📖 배운 것
- local에 객체 타입을 저장할려면 json으로 변환하여 저장해줘야 한다는 것을 알았다. 나는 gson을 사용했다. 
- 객체 타입을 저장하기 위해선 protoDatastore도 사용할 수 있다고 한다.

### 📝 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - User information is now automatically fetched and displayed in the MyPage and Update Profile screens, providing up-to-date profile details.
  - User profile data is securely stored and managed locally for improved performance and offline access.
  - Added support for retrieving user profile data from the server and caching it locally.

- **Improvements**
  - Enhanced data synchronization between local storage and remote sources for user information.
  - Streamlined user profile update and retrieval processes for a smoother user experience.
  - Improved logout and unregister processes to clear user data concurrently for better security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->