### PR TITLE
[Feature] 프로필 편집  API 연동

### DIFF
--- a/core/data/src/main/java/com/example/data/repository/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/example/data/repository/UserRepositoryImpl.kt
@@ -1,10 +1,11 @@
 package com.example.data.repository
 
 import com.example.common.util.suspendRunCatching
+import com.example.data.image.ImageResizer
 import com.example.datastore.datasource.token.LocalTokenDataSource
 import com.example.datastore.datasource.user.LocalUserDataSource
+import com.example.domain.model.user.UserInfo
 import com.example.domain.repository.UserRepository
-import com.example.domain.user.UserInfo
 import com.example.network.source.auth.AuthDataSource
 import com.example.network.source.user.UserDataSource
 import kotlinx.coroutines.flow.first
@@ -16,6 +17,7 @@ class UserRepositoryImpl @Inject constructor(
     private val authDataSource: AuthDataSource,
     private val userDataSource: UserDataSource,
     private val localUserDataSource: LocalUserDataSource,
+    private val imageResizer: ImageResizer,
 ) : UserRepository {
     override suspend fun checkTokenHealth(): Result<Unit> = suspendRunCatching {
         val token = localTokenDataSource.accessToken.first()
@@ -41,4 +43,14 @@ class UserRepositoryImpl @Inject constructor(
         localUserDataSource.setUserInfo(userInfo)
         userInfo
     }
+
+    override suspend fun updateNickname(nickname: String): Result<Unit> = suspendRunCatching {
+        userDataSource.updateNickname(nickname)
+    }
+
+    override suspend fun updateProfileImage(profileImageUrl: String?): Result<Unit> =
+        suspendRunCatching {
+            val uploadImageUrl = profileImageUrl?.let { imageResizer.resizeImage(profileImageUrl) }
+            userDataSource.updateProfileImage(uploadImageUrl)
+        }
 }

--- a/core/datastore/src/main/java/com/example/datastore/datasource/user/LocalUserDataSource.kt
+++ b/core/datastore/src/main/java/com/example/datastore/datasource/user/LocalUserDataSource.kt
@@ -1,6 +1,6 @@
 package com.example.datastore.datasource.user
 
-import com.example.domain.user.UserInfo
+import com.example.domain.model.user.UserInfo
 import kotlinx.coroutines.flow.Flow
 
 interface LocalUserDataSource {

--- a/core/datastore/src/main/java/com/example/datastore/datasource/user/LocalUserDataSourceImpl.kt
+++ b/core/datastore/src/main/java/com/example/datastore/datasource/user/LocalUserDataSourceImpl.kt
@@ -7,7 +7,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.example.datastore.util.fromJsonOrNull
-import com.example.domain.user.UserInfo
+import com.example.domain.model.user.UserInfo
 import com.google.gson.Gson
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch

--- a/core/domain/src/main/java/com/example/domain/model/user/UserInfo.kt
+++ b/core/domain/src/main/java/com/example/domain/model/user/UserInfo.kt
@@ -1,4 +1,4 @@
-package com.example.domain.user
+package com.example.domain.model.user
 
 data class UserInfo(
     val name : String,

--- a/core/domain/src/main/java/com/example/domain/repository/UserRepository.kt
+++ b/core/domain/src/main/java/com/example/domain/repository/UserRepository.kt
@@ -1,9 +1,11 @@
 package com.example.domain.repository
 
-import com.example.domain.user.UserInfo
+import com.example.domain.model.user.UserInfo
 
 interface UserRepository {
-    suspend fun checkTokenHealth() : Result<Unit>
-    suspend fun getUserInfo() : Result<UserInfo>
-    suspend fun loadUserInfo() : Result<UserInfo>
+    suspend fun checkTokenHealth(): Result<Unit>
+    suspend fun getUserInfo(): Result<UserInfo>
+    suspend fun loadUserInfo(): Result<UserInfo>
+    suspend fun updateNickname(nickname: String): Result<Unit>
+    suspend fun updateProfileImage(profileImageUrl: String?): Result<Unit>
 }

--- a/core/network/src/main/java/com/example/network/api/TraceApi.kt
+++ b/core/network/src/main/java/com/example/network/api/TraceApi.kt
@@ -19,6 +19,7 @@ import com.example.network.model.token.CheckTokenHealthRequest
 import com.example.network.model.token.CheckTokenHealthResponse
 import com.example.network.model.token.RefreshTokenRequest
 import com.example.network.model.user.LoadUserInfoResponse
+import com.example.network.model.user.UpdateNicknameRequest
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import retrofit2.http.Body
@@ -51,6 +52,17 @@ interface TraceApi {
 
     @GET("/api/v1/user")
     suspend fun loadUserInfo(): Result<LoadUserInfoResponse>
+
+    @PUT("/api/v1/user/profile/nickname")
+    suspend fun updateNickname(
+        @Body updateNicknameRequest : UpdateNicknameRequest
+    ) : Result<LoadUserInfoResponse>
+
+    @Multipart
+    @PUT("/api/v1/user/profile/image")
+    suspend fun updateProfileImage(
+        @Part profileImage: MultipartBody.Part? = null
+    ) : Result<LoadUserInfoResponse>
 
     // 토큰
     @HTTP(method = "POST", path = "/api/v1/token/refresh", hasBody = true)

--- a/core/network/src/main/java/com/example/network/model/user/UpdateNicknameRequest.kt
+++ b/core/network/src/main/java/com/example/network/model/user/UpdateNicknameRequest.kt
@@ -1,0 +1,8 @@
+package com.example.network.model.user
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UpdateNicknameRequest(
+    val nickname : String
+)

--- a/core/network/src/main/java/com/example/network/source/auth/AuthDataSourceImpl.kt
+++ b/core/network/src/main/java/com/example/network/source/auth/AuthDataSourceImpl.kt
@@ -80,5 +80,4 @@ class AuthDataSourceImpl @Inject constructor(
         private const val WEBP_MEDIA_TYPE = "image/webp"
         private const val JPEG_MEDIA_TYPE = "image/jpeg"
     }
-
 }

--- a/core/network/src/main/java/com/example/network/source/user/UserDataSource.kt
+++ b/core/network/src/main/java/com/example/network/source/user/UserDataSource.kt
@@ -1,7 +1,10 @@
 package com.example.network.source.user
 
 import com.example.network.model.user.LoadUserInfoResponse
+import java.io.InputStream
 
 interface UserDataSource {
-    suspend fun loadUserInfo() : Result<LoadUserInfoResponse>
+    suspend fun loadUserInfo(): Result<LoadUserInfoResponse>
+    suspend fun updateNickname(nickname: String): Result<LoadUserInfoResponse>
+    suspend fun updateProfileImage(profileImage: InputStream?): Result<LoadUserInfoResponse>
 }

--- a/core/network/src/main/java/com/example/network/source/user/UserDataSourceImpl.kt
+++ b/core/network/src/main/java/com/example/network/source/user/UserDataSourceImpl.kt
@@ -1,11 +1,48 @@
 package com.example.network.source.user
 
+import android.os.Build
 import com.example.network.api.TraceApi
 import com.example.network.model.user.LoadUserInfoResponse
+import com.example.network.model.user.UpdateNicknameRequest
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.InputStream
+import java.util.UUID
 import javax.inject.Inject
 
 class UserDataSourceImpl @Inject constructor(
     private val traceApi: TraceApi,
 ) : UserDataSource {
     override suspend fun loadUserInfo(): Result<LoadUserInfoResponse> = traceApi.loadUserInfo()
+    override suspend fun updateNickname(nickname: String): Result<LoadUserInfoResponse> =
+        traceApi.updateNickname(
+            updateNicknameRequest = UpdateNicknameRequest(nickname)
+        )
+
+    override suspend fun updateProfileImage(profileImage: InputStream?): Result<LoadUserInfoResponse> {
+        val (imageFileExtension, imageFileName) = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            WEBP_MEDIA_TYPE to "profile_${UUID.randomUUID()}.webp"
+        } else {
+            JPEG_MEDIA_TYPE to "profile_${UUID.randomUUID()}.jpg"
+        }
+
+        val mediaType = imageFileExtension.toMediaTypeOrNull()
+            ?: throw IllegalArgumentException("Invalid media type: $imageFileExtension")
+
+        val requestImage = profileImage?.let {
+            MultipartBody.Part.createFormData(
+                name = "profileImage",
+                filename = imageFileName,
+                body = profileImage.readBytes().toRequestBody(mediaType)
+            )
+        }
+
+        return traceApi.updateProfileImage(requestImage)
+    }
+
+    companion object {
+        private const val WEBP_MEDIA_TYPE = "image/webp"
+        private const val JPEG_MEDIA_TYPE = "image/jpeg"
+    }
 }

--- a/feature/mypage/src/main/java/com/example/mypage/graph/mypage/MyPageScreen.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/graph/mypage/MyPageScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -27,6 +28,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.common.util.clickable
 import com.example.designsystem.R
@@ -63,6 +67,21 @@ internal fun MyPageRoute(
                 is MyPageEvent.NavigateToEditProfile -> navigateToEditProfile()
                 is MyPageEvent.NavigateToSetting -> navigateToSetting()
             }
+        }
+    }
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.getUserInfo()
+            }
+        }
+
+        lifecycleOwner.lifecycle.addObserver(observer)
+
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
         }
     }
 

--- a/feature/mypage/src/main/java/com/example/mypage/graph/mypage/MyPageScreen.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/graph/mypage/MyPageScreen.kt
@@ -39,7 +39,7 @@ import com.example.designsystem.theme.TabIndicator
 import com.example.designsystem.theme.TraceTheme
 import com.example.domain.model.mypage.MyPageTab
 import com.example.domain.model.post.PostFeed
-import com.example.domain.user.UserInfo
+import com.example.domain.model.user.UserInfo
 import com.example.mypage.graph.mypage.MyPageViewModel.MyPageEvent
 
 

--- a/feature/mypage/src/main/java/com/example/mypage/graph/mypage/MyPageViewModel.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/graph/mypage/MyPageViewModel.kt
@@ -5,8 +5,8 @@ import androidx.lifecycle.viewModelScope
 import com.example.domain.model.mypage.MyPageTab
 import com.example.domain.model.post.PostFeed
 import com.example.domain.model.post.PostType
-import com.example.domain.repository.UserRepository
 import com.example.domain.model.user.UserInfo
+import com.example.domain.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -50,7 +50,7 @@ class MyPageViewModel @Inject constructor(
     private val _reactedPosts: MutableStateFlow<List<PostFeed>> = MutableStateFlow(fakePostFeeds)
     val reactedPosts = _reactedPosts.asStateFlow()
 
-    private fun getUserInfo() = viewModelScope.launch {
+    fun getUserInfo() = viewModelScope.launch {
         userRepository.getUserInfo().onSuccess { userInfo ->
             _userInfo.value = userInfo
         }

--- a/feature/mypage/src/main/java/com/example/mypage/graph/mypage/MyPageViewModel.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/graph/mypage/MyPageViewModel.kt
@@ -6,7 +6,7 @@ import com.example.domain.model.mypage.MyPageTab
 import com.example.domain.model.post.PostFeed
 import com.example.domain.model.post.PostType
 import com.example.domain.repository.UserRepository
-import com.example.domain.user.UserInfo
+import com.example.domain.model.user.UserInfo
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/feature/mypage/src/main/java/com/example/mypage/graph/updateprofile/UpdateProfileScreen.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/graph/updateprofile/UpdateProfileScreen.kt
@@ -69,6 +69,10 @@ internal fun UpdateProfileRoute(
     val name by viewModel.name.collectAsStateWithLifecycle()
     val isNameValid by viewModel.isNameValid.collectAsStateWithLifecycle()
     val profileImageUrl by viewModel.profileImage.collectAsStateWithLifecycle()
+    val isNameChanged by viewModel.isNameChanged.collectAsStateWithLifecycle()
+    val isProfileImageChanged by viewModel.isProfileImageChanged.collectAsStateWithLifecycle()
+    val isChanged = isNameChanged || isProfileImageChanged
+
 
     LaunchedEffect(true) {
         viewModel.eventChannel.collect { event ->
@@ -83,6 +87,7 @@ internal fun UpdateProfileRoute(
         name = name,
         isNameValid = isNameValid,
         profileImageUrl = profileImageUrl,
+        isChanged = isChanged,
         onNameChange = viewModel::setName,
         onProfileImageUrlChange = viewModel::setProfileImageUrl,
         updateProfile = viewModel::updateProfile
@@ -95,9 +100,10 @@ private fun UpdateProfileScreen(
     name: String,
     isNameValid: Boolean,
     profileImageUrl: String?,
+    isChanged: Boolean,
     onNameChange: (String) -> Unit,
     onProfileImageUrlChange: (String?) -> Unit,
-    updateProfile : () -> Unit
+    updateProfile: () -> Unit
 ) {
     val imageLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.PickVisualMedia(),
@@ -115,9 +121,9 @@ private fun UpdateProfileScreen(
         listOf("사진/앨범에서 불러오기")
     }
 
-    val editProfileAvailability by remember(name, isNameValid) {
+    val editProfileAvailability by remember(isNameValid, isChanged) {
         derivedStateOf {
-            name.isNotEmpty() && isNameValid
+            isNameValid && isChanged
         }
     }
 
@@ -335,6 +341,7 @@ fun SettingScreenPreview() {
         navigateBack = {}, profileImageUrl = null,
         isNameValid = true, name = "닉네임", onNameChange = {},
         onProfileImageUrlChange = {},
+        isChanged = true,
         updateProfile = {}
     )
 }

--- a/feature/mypage/src/main/java/com/example/mypage/graph/updateprofile/UpdateProfileViewModel.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/graph/updateprofile/UpdateProfileViewModel.kt
@@ -2,6 +2,8 @@ package com.example.mypage.graph.updateprofile
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.common.event.EventHelper
+import com.example.common.event.TraceEvent
 import com.example.domain.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
@@ -13,7 +15,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class UpdateProfileViewModel @Inject constructor(
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val eventHelper: EventHelper
 ) : ViewModel() {
     private val _eventChannel = Channel<UpdateProfileEvent>()
     val eventChannel = _eventChannel.receiveAsFlow()
@@ -27,12 +30,24 @@ class UpdateProfileViewModel @Inject constructor(
     private val _profileImageUrl = MutableStateFlow<String?>(null)
     val profileImage = _profileImageUrl.asStateFlow()
 
+    private val _isNameChanged = MutableStateFlow(false)
+    val isNameChanged = _isNameChanged.asStateFlow()
+
+    private val _isProfileImageChanged = MutableStateFlow(false)
+    val isProfileImageChanged = _isProfileImageChanged.asStateFlow()
+
+    private var originalName: String = ""
+    private var originalProfileImageUrl: String? = null
+
     init {
         getUserInfo()
     }
 
     private fun getUserInfo() = viewModelScope.launch {
         userRepository.loadUserInfo().onSuccess { userInfo ->
+            originalName = userInfo.name
+            originalProfileImageUrl = userInfo.profileImageUrl
+
             setName(userInfo.name)
             setProfileImageUrl(userInfo.profileImageUrl)
         }
@@ -41,10 +56,12 @@ class UpdateProfileViewModel @Inject constructor(
     fun setName(name: String) {
         _name.value = name
         validateName()
+        _isNameChanged.value = _name.value != originalName
     }
 
     fun setProfileImageUrl(imageUrl: String?) {
         _profileImageUrl.value = imageUrl
+        _isProfileImageChanged.value = _profileImageUrl.value != originalProfileImageUrl
     }
 
     private fun validateName() {
@@ -52,8 +69,31 @@ class UpdateProfileViewModel @Inject constructor(
         _isNameValid.value = _name.value.trim().matches(nicknameRegex)
     }
 
-    fun updateProfile() {}
+    fun updateProfile() {
+        if (!_isNameChanged.value && !_isProfileImageChanged.value) return
 
+        viewModelScope.launch {
+            var success = true
+
+            if (_isNameChanged.value) {
+                val result = userRepository.updateNickname(_name.value)
+                if (result.isFailure) success = false
+            }
+
+            if (_isProfileImageChanged.value) {
+                val result = userRepository.updateProfileImage(_profileImageUrl.value)
+                if (result.isFailure) success = false
+            }
+
+            if (!success) {
+                userRepository.loadUserInfo().onSuccess {
+                    _eventChannel.send(UpdateProfileEvent.NavigateBack)
+                }
+            } else {
+                eventHelper.sendEvent(TraceEvent.ShowSnackBar("프로필 수정에 실패했습니다."))
+            }
+        }
+    }
 
     companion object {
         private const val NAME_MIN_LENGTH = 2

--- a/feature/mypage/src/main/java/com/example/mypage/graph/updateprofile/UpdateProfileViewModel.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/graph/updateprofile/UpdateProfileViewModel.kt
@@ -85,7 +85,7 @@ class UpdateProfileViewModel @Inject constructor(
                 if (result.isFailure) success = false
             }
 
-            if (!success) {
+            if (success) {
                 userRepository.loadUserInfo().onSuccess {
                     _eventChannel.send(UpdateProfileEvent.NavigateBack)
                 }


### PR DESCRIPTION
### 🚀 변경 사항 🚀
- 닉네임 수정 API
- 프로필 이미지 수정 API
- 프로필 수정 후 마이페이지에 반영

### 📸 스크린샷
![프로필 수정](https://github.com/user-attachments/assets/4ba4ae98-b3e2-4d78-9b3b-ec63c7e530cc)

### 📖 배운 것
```kotlin
   DisposableEffect(lifecycleOwner) {
        val observer = LifecycleEventObserver { _, event ->
            if (event == Lifecycle.Event.ON_RESUME) {
                viewModel.getUserInfo()
            }
        }

        lifecycleOwner.lifecycle.addObserver(observer)

        onDispose {
            lifecycleOwner.lifecycle.removeObserver(observer)
        }
    }
```
- 프로필 수정 완료 -> popUp 후 마이페이지 화면으로 돌아감
- 이 과정에서 마이페이지에 수정된 프로필이 반영되지 않기 때문에 LifeCycleObserver를 활용했다. 하지만 메모리 누수가 클 것 같아 다른 방안도 고려해보아야 겠다.

### 📝 참고사항
