### PR TITLE
[Feature] 마이페이지 게시글 조회 API 연동

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -13,9 +13,6 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
-      <SelectionState runConfigName="MyPageScreenPreview">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/core/data/src/main/java/com/example/data/paging/MyPostPagingSource.kt
+++ b/core/data/src/main/java/com/example/data/paging/MyPostPagingSource.kt
@@ -2,31 +2,26 @@ package com.example.data.paging
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
+import com.example.domain.model.mypage.MyPageTab
 import com.example.domain.model.post.PostFeed
-import com.example.domain.model.search.SearchType
-import com.example.domain.model.search.SearchTab
 import com.example.network.model.cursor.Cursor
-import com.example.network.source.search.SearchDataSource
+import com.example.network.source.post.PostDataSource
 
-class SearchPagingSource(
-    private val searchDataSource: SearchDataSource,
-    private val keyword: String,
-    private val tabType: SearchTab,
-    private val searchType: SearchType,
-    private val pageSize: Int = 10,
+class MyPostPagingSource(
+    private val postDatasource: PostDataSource,
+    private val tabType: MyPageTab,
+    private val pageSize: Int = 20
 ) : PagingSource<Cursor, PostFeed>() {
 
     override suspend fun load(params: LoadParams<Cursor>): LoadResult<Cursor, PostFeed> {
         return try {
             val cursor = params.key
 
-            val response = searchDataSource.searchPosts(
+            val response = postDatasource.getMyPosts(
                 cursorDateTime = cursor?.dateTime,
                 cursorId = cursor?.id,
                 size = pageSize,
-                keyword = keyword,
-                tabType = tabType,
-                searchType = searchType
+                tabType = tabType
             ).getOrThrow()
 
             val postFeeds = response.toDomain()

--- a/core/data/src/main/java/com/example/data/paging/MyPostPagingSource.kt
+++ b/core/data/src/main/java/com/example/data/paging/MyPostPagingSource.kt
@@ -1,5 +1,6 @@
 package com.example.data.paging
 
+import android.util.Log
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.example.domain.model.mypage.MyPageTab

--- a/core/data/src/main/java/com/example/data/paging/PostPagingSource.kt
+++ b/core/data/src/main/java/com/example/data/paging/PostPagingSource.kt
@@ -2,15 +2,14 @@ package com.example.data.paging
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
+import com.example.domain.model.post.HomeTab
 import com.example.domain.model.post.PostFeed
-import com.example.domain.model.post.TabType
 import com.example.network.model.cursor.Cursor
 import com.example.network.source.post.PostDataSource
 
-
 class PostPagingSource(
     private val postDatasource: PostDataSource,
-    private val tabType: TabType,
+    private val tabType: HomeTab,
     private val pageSize: Int = 20
 ) : PagingSource<Cursor, PostFeed>() {
 

--- a/core/data/src/main/java/com/example/data/repository/PostRepositoryImpl.kt
+++ b/core/data/src/main/java/com/example/data/repository/PostRepositoryImpl.kt
@@ -5,11 +5,13 @@ import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import com.example.common.util.suspendRunCatching
 import com.example.data.image.ImageResizer
+import com.example.data.paging.MyPostPagingSource
 import com.example.data.paging.PostPagingSource
+import com.example.domain.model.mypage.MyPageTab
 import com.example.domain.model.post.Emotion
+import com.example.domain.model.post.HomeTab
 import com.example.domain.model.post.PostDetail
 import com.example.domain.model.post.PostFeed
-import com.example.domain.model.post.TabType
 import com.example.domain.model.post.WritePostType
 import com.example.domain.repository.PostRepository
 import com.example.network.source.post.PostDataSource
@@ -20,11 +22,20 @@ class PostRepositoryImpl @Inject constructor(
     private val postDataSource: PostDataSource,
     private val imageResizer: ImageResizer,
 ) : PostRepository {
-    override fun getPostPagingFlow(tabType: TabType): Flow<PagingData<PostFeed>> {
+    override fun getPosts(tabType: HomeTab): Flow<PagingData<PostFeed>> {
         return Pager(
             config = PagingConfig(pageSize = DEFAULT_PAGE_SIZE),
             pagingSourceFactory = {
                 PostPagingSource(postDataSource, tabType)
+            }
+        ).flow
+    }
+
+    override fun getMyPosts(tabType: MyPageTab): Flow<PagingData<PostFeed>> {
+        return Pager(
+            config = PagingConfig(pageSize = DEFAULT_PAGE_SIZE),
+            pagingSourceFactory = {
+                MyPostPagingSource(postDataSource, tabType)
             }
         ).flow
     }

--- a/core/data/src/main/java/com/example/data/repository/SearchRepositoryImpl.kt
+++ b/core/data/src/main/java/com/example/data/repository/SearchRepositoryImpl.kt
@@ -7,8 +7,9 @@ import com.example.common.util.suspendRunCatching
 import com.example.data.paging.SearchPagingSource
 import com.example.datastore.datasource.keyword.LocalKeywordDataSource
 import com.example.domain.model.post.PostFeed
-import com.example.domain.model.post.SearchType
-import com.example.domain.model.post.TabType
+import com.example.domain.model.search.SearchType
+
+import com.example.domain.model.search.SearchTab
 import com.example.domain.repository.SearchRepository
 import com.example.network.source.search.SearchDataSource
 import kotlinx.coroutines.flow.Flow
@@ -21,7 +22,7 @@ class SearchRepositoryImpl @Inject constructor(
 ) : SearchRepository {
     override suspend fun searchPosts(
         keyword: String,
-        tabType: TabType,
+        tabType: SearchTab,
         searchType: SearchType
     ): Flow<PagingData<PostFeed>> {
         return Pager(

--- a/core/domain/src/main/java/com/example/domain/model/post/Post.kt
+++ b/core/domain/src/main/java/com/example/domain/model/post/Post.kt
@@ -74,12 +74,13 @@ data class PostDetail(
     }
 }
 
-enum class TabType(val label: String) {
+enum class HomeTab(val label: String) {
     ALL("전체"),
     FREE("자유"),
     GOOD_DEED("선행"),
     MISSION("미션")
 }
+
 
 enum class PostType(val label: String) {
     FREE("자유"),

--- a/core/domain/src/main/java/com/example/domain/model/post/Post.kt
+++ b/core/domain/src/main/java/com/example/domain/model/post/Post.kt
@@ -51,21 +51,21 @@ data class PostFeed(
 }
 
 data class PostDetail(
-    val postId : Int,
+    val postId: Int,
     val postType: PostType,
     val viewCount: Int,
     val emotionCount: EmotionCount,
     val title: String,
     val content: String,
-    val missionContent : String? = null,
-    val providerId :String,
+    val missionContent: String? = null,
+    val providerId:String,
     val nickname: String,
     val images: List<String> = emptyList(),
     val profileImageUrl: String? = null,
-    val yourEmotionType : Emotion? = null,
+    val yourEmotionType: Emotion? = null,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime,
-    val isOwner : Boolean = true,
+    val isOwner: Boolean = true,
     val isVerified: Boolean = false,
 ) {
     fun getFormattedDate(): String {

--- a/core/domain/src/main/java/com/example/domain/model/search/SearchCondition.kt
+++ b/core/domain/src/main/java/com/example/domain/model/search/SearchCondition.kt
@@ -1,11 +1,9 @@
 package com.example.domain.model.search
 
-import com.example.domain.model.post.SearchType
-import com.example.domain.model.post.TabType
 
 data class SearchCondition(
     val keyword: String,
-    val tabType: TabType,
+    val tabType: SearchTab,
     val searchType: SearchType,
     val isSearched: Boolean
 )

--- a/core/domain/src/main/java/com/example/domain/model/search/SearchTab.kt
+++ b/core/domain/src/main/java/com/example/domain/model/search/SearchTab.kt
@@ -1,0 +1,8 @@
+package com.example.domain.model.search
+
+enum class SearchTab(val label: String) {
+    ALL("전체"),
+    FREE("자유"),
+    GOOD_DEED("선행"),
+    MISSION("미션")
+}

--- a/core/domain/src/main/java/com/example/domain/model/search/SearchType.kt
+++ b/core/domain/src/main/java/com/example/domain/model/search/SearchType.kt
@@ -1,4 +1,4 @@
-package com.example.domain.model.post
+package com.example.domain.model.search
 
 enum class SearchType(val label : String) {
     ALL("전체"),

--- a/core/domain/src/main/java/com/example/domain/repository/PostRepository.kt
+++ b/core/domain/src/main/java/com/example/domain/repository/PostRepository.kt
@@ -1,16 +1,18 @@
 package com.example.domain.repository
 
 import androidx.paging.PagingData
+import com.example.domain.model.mypage.MyPageTab
 import com.example.domain.model.post.Emotion
+import com.example.domain.model.post.HomeTab
 import com.example.domain.model.post.PostDetail
-import com.example.domain.model.post.PostFeed
-import com.example.domain.model.post.TabType
-import com.example.domain.model.post.WritePostType
+import com.example.domain.model.post.PostFeed import com.example.domain.model.post.WritePostType
 import kotlinx.coroutines.flow.Flow
 
 
 interface PostRepository {
-    fun getPostPagingFlow(tabType: TabType): Flow<PagingData<PostFeed>>
+    fun getPosts(tabType: HomeTab): Flow<PagingData<PostFeed>>
+
+    fun getMyPosts(tabType: MyPageTab) : Flow<PagingData<PostFeed>>
 
     suspend fun getPost(postId: Int): Result<PostDetail>
 

--- a/core/domain/src/main/java/com/example/domain/repository/PostRepository.kt
+++ b/core/domain/src/main/java/com/example/domain/repository/PostRepository.kt
@@ -5,7 +5,8 @@ import com.example.domain.model.mypage.MyPageTab
 import com.example.domain.model.post.Emotion
 import com.example.domain.model.post.HomeTab
 import com.example.domain.model.post.PostDetail
-import com.example.domain.model.post.PostFeed import com.example.domain.model.post.WritePostType
+import com.example.domain.model.post.PostFeed
+import com.example.domain.model.post.WritePostType
 import kotlinx.coroutines.flow.Flow
 
 

--- a/core/domain/src/main/java/com/example/domain/repository/SearchRepository.kt
+++ b/core/domain/src/main/java/com/example/domain/repository/SearchRepository.kt
@@ -2,12 +2,12 @@ package com.example.domain.repository
 
 import androidx.paging.PagingData
 import com.example.domain.model.post.PostFeed
-import com.example.domain.model.post.SearchType
-import com.example.domain.model.post.TabType
+import com.example.domain.model.search.SearchType
+import com.example.domain.model.search.SearchTab
 import kotlinx.coroutines.flow.Flow
 
 interface SearchRepository {
-    suspend fun searchPosts(keyword: String, tabType : TabType, searchType: SearchType) : Flow<PagingData<PostFeed>>
+    suspend fun searchPosts(keyword: String, tabType : SearchTab, searchType: SearchType) : Flow<PagingData<PostFeed>>
     suspend fun getRecentKeywords(): Result<List<String>>
     suspend fun addKeyword(keyword : String) : Result<Unit>
     suspend fun removeKeyword(keyword: String) : Result<Unit>

--- a/core/network/src/main/java/com/example/network/api/TraceApi.kt
+++ b/core/network/src/main/java/com/example/network/api/TraceApi.kt
@@ -10,6 +10,7 @@ import com.example.network.model.comment.GetCommentsRequest
 import com.example.network.model.comment.GetCommentsResponse
 import com.example.network.model.mission.DailyMissionResponse
 import com.example.network.model.notification.PostDeviceTokenRequest
+import com.example.network.model.post.GetMyPostsRequest
 import com.example.network.model.post.GetPostsRequest
 import com.example.network.model.post.GetPostsResponse
 import com.example.network.model.post.PostResponse
@@ -155,6 +156,10 @@ interface TraceApi {
         @Part("request") verifyMissionRequest: RequestBody,
         @Part imageFiles: List<MultipartBody.Part>? = null
     ): Result<PostResponse>
+
+    // 마이페이지
+    @POST("/api/v1/posts/my")
+    suspend fun getMyPosts(@Body getMyPostsRequest: GetMyPostsRequest): Result<GetPostsResponse>
 
     // 알림
     @POST("/api/v1/fcm/tokens")

--- a/core/network/src/main/java/com/example/network/api/TraceApi.kt
+++ b/core/network/src/main/java/com/example/network/api/TraceApi.kt
@@ -158,7 +158,7 @@ interface TraceApi {
     ): Result<PostResponse>
 
     // 마이페이지
-    @POST("/api/v1/posts/my")
+    @POST("/api/v1/user/myPosts")
     suspend fun getMyPosts(@Body getMyPostsRequest: GetMyPostsRequest): Result<GetPostsResponse>
 
     // 알림

--- a/core/network/src/main/java/com/example/network/model/post/GetMyPostsRequest.kt
+++ b/core/network/src/main/java/com/example/network/model/post/GetMyPostsRequest.kt
@@ -8,5 +8,5 @@ data class GetMyPostsRequest(
     val cursorDateTime : LocalDateTime?,
     val cursorId : Int?,
     val size : Int,
-    val tabType : String
+    val myPageTab : String
 )

--- a/core/network/src/main/java/com/example/network/model/post/GetMyPostsRequest.kt
+++ b/core/network/src/main/java/com/example/network/model/post/GetMyPostsRequest.kt
@@ -1,0 +1,12 @@
+package com.example.network.model.post
+
+import kotlinx.datetime.LocalDateTime
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GetMyPostsRequest(
+    val cursorDateTime : LocalDateTime?,
+    val cursorId : Int?,
+    val size : Int,
+    val tabType : String
+)

--- a/core/network/src/main/java/com/example/network/model/post/GetPostRequest.kt
+++ b/core/network/src/main/java/com/example/network/model/post/GetPostRequest.kt
@@ -1,8 +1,0 @@
-package com.example.network.model.post
-
-import kotlinx.serialization.Serializable
-
-@Serializable
-data class GetPostRequest(
-   val postId : Int,
-)

--- a/core/network/src/main/java/com/example/network/source/post/PostDataSource.kt
+++ b/core/network/src/main/java/com/example/network/source/post/PostDataSource.kt
@@ -1,8 +1,9 @@
 package com.example.network.source.post
 
 
+import com.example.domain.model.mypage.MyPageTab
 import com.example.domain.model.post.Emotion
-import com.example.domain.model.post.TabType
+import com.example.domain.model.post.HomeTab
 import com.example.domain.model.post.WritePostType
 import com.example.network.model.post.GetPostsResponse
 import com.example.network.model.post.PostResponse
@@ -15,7 +16,14 @@ interface PostDataSource {
         cursorDateTime : LocalDateTime?,
         cursorId : Int?,
         size : Int,
-        postType : TabType
+        postType : HomeTab
+    ) : Result<GetPostsResponse>
+
+    suspend fun getMyPosts(
+        cursorDateTime : LocalDateTime?,
+        cursorId : Int?,
+        size : Int,
+        tabType: MyPageTab
     ) : Result<GetPostsResponse>
 
     suspend fun getPost(

--- a/core/network/src/main/java/com/example/network/source/post/PostDataSourceImpl.kt
+++ b/core/network/src/main/java/com/example/network/source/post/PostDataSourceImpl.kt
@@ -1,12 +1,14 @@
 package com.example.network.source.post
 
 import android.os.Build
+import com.example.domain.model.mypage.MyPageTab
 import com.example.domain.model.post.Emotion
+import com.example.domain.model.post.HomeTab
 import com.example.domain.model.post.PostType
-import com.example.domain.model.post.TabType
 import com.example.domain.model.post.WritePostType
 import com.example.network.api.TraceApi
 import com.example.network.model.post.AddPostRequest
+import com.example.network.model.post.GetMyPostsRequest
 import com.example.network.model.post.GetPostsRequest
 import com.example.network.model.post.GetPostsResponse
 import com.example.network.model.post.PostResponse
@@ -31,13 +33,27 @@ class PostDataSourceImpl @Inject constructor(
         cursorDateTime: LocalDateTime?,
         cursorId: Int?,
         size: Int,
-        postType: TabType
+        postType: HomeTab
     ): Result<GetPostsResponse> = traceApi.getPosts(
         getPostsRequest = GetPostsRequest(
             cursorDateTime = cursorDateTime,
             cursorId = cursorId,
             size = size,
-            postType = if (postType == TabType.ALL) null else postType.name
+            postType = if (postType == HomeTab.ALL) null else postType.name
+        )
+    )
+
+    override suspend fun getMyPosts(
+        cursorDateTime: LocalDateTime?,
+        cursorId: Int?,
+        size: Int,
+        tabType: MyPageTab
+    ): Result<GetPostsResponse> = traceApi.getMyPosts(
+        getMyPostsRequest = GetMyPostsRequest(
+            cursorDateTime = cursorDateTime,
+            cursorId = cursorId,
+            size = size,
+            tabType = tabType.name
         )
     )
 

--- a/core/network/src/main/java/com/example/network/source/post/PostDataSourceImpl.kt
+++ b/core/network/src/main/java/com/example/network/source/post/PostDataSourceImpl.kt
@@ -53,7 +53,7 @@ class PostDataSourceImpl @Inject constructor(
             cursorDateTime = cursorDateTime,
             cursorId = cursorId,
             size = size,
-            tabType = tabType.name
+            myPageTab = tabType.name
         )
     )
 

--- a/core/network/src/main/java/com/example/network/source/search/SearchDataSource.kt
+++ b/core/network/src/main/java/com/example/network/source/search/SearchDataSource.kt
@@ -1,7 +1,8 @@
 package com.example.network.source.search
 
-import com.example.domain.model.post.SearchType
-import com.example.domain.model.post.TabType
+
+import com.example.domain.model.search.SearchType
+import com.example.domain.model.search.SearchTab
 import com.example.network.model.post.GetPostsResponse
 import kotlinx.datetime.LocalDateTime
 
@@ -10,7 +11,7 @@ interface SearchDataSource {
         cursorDateTime: LocalDateTime?,
         cursorId: Int?,
         size: Int,
-        tabType: TabType,
+        tabType: SearchTab,
         keyword: String,
         searchType: SearchType
     ): Result<GetPostsResponse>

--- a/core/network/src/main/java/com/example/network/source/search/SearchDataSourceImpl.kt
+++ b/core/network/src/main/java/com/example/network/source/search/SearchDataSourceImpl.kt
@@ -1,7 +1,7 @@
 package com.example.network.source.search
 
-import com.example.domain.model.post.SearchType
-import com.example.domain.model.post.TabType
+import com.example.domain.model.search.SearchTab
+import com.example.domain.model.search.SearchType
 import com.example.network.api.TraceApi
 import com.example.network.model.post.GetPostsResponse
 import com.example.network.model.search.SearchPostsRequest
@@ -15,7 +15,7 @@ class SearchDataSourceImpl @Inject constructor(
         cursorDateTime: LocalDateTime?,
         cursorId: Int?,
         size: Int,
-        tabType: TabType,
+        tabType: SearchTab,
         keyword: String,
         searchType: SearchType
     ): Result<GetPostsResponse> = traceApi.searchPosts(
@@ -23,7 +23,7 @@ class SearchDataSourceImpl @Inject constructor(
             cursorDateTime = cursorDateTime,
             cursorId = cursorId,
             size = size,
-            postType = if(tabType != TabType.ALL) tabType.name else null,
+            postType = if(tabType != SearchTab.ALL) tabType.name else null,
             keyword = keyword,
             searchType = searchType.name
         )

--- a/feature/home/src/main/java/com/example/home/graph/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/example/home/graph/home/HomeScreen.kt
@@ -50,13 +50,15 @@ import com.example.designsystem.theme.GrayLine
 import com.example.designsystem.theme.PrimaryDefault
 import com.example.designsystem.theme.TraceTheme
 import com.example.designsystem.theme.White
+import com.example.domain.model.post.HomeTab
 import com.example.domain.model.post.PostFeed
-import com.example.domain.model.post.TabType
+import com.example.domain.model.post.PostType
 import com.example.home.graph.home.HomeViewModel.HomeEvent
 import com.example.home.graph.home.component.HomeDropDownMenu
 import com.example.home.graph.home.component.TabSelector
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
+import java.time.LocalDateTime
 
 
 @Composable
@@ -66,7 +68,7 @@ internal fun HomeRoute(
     navigateToWritePost: () -> Unit,
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
-    val postFeeds = viewModel.postPagingFlow.collectAsLazyPagingItems()
+    val postFeeds = viewModel.postFeeds.collectAsLazyPagingItems()
     val tabType by viewModel.tabType.collectAsStateWithLifecycle()
 
     LaunchedEffect(true) {
@@ -94,8 +96,8 @@ internal fun HomeRoute(
 @Composable
 private fun HomeScreen(
     postFeeds: LazyPagingItems<PostFeed>,
-    tabType: TabType,
-    onTabTypeChange: (TabType) -> Unit,
+    tabType: HomeTab,
+    onTabTypeChange: (HomeTab) -> Unit,
     navigateToSearch: () -> Unit,
     navigateToPost: (Int) -> Unit,
     navigateToWritePost: () -> Unit,
@@ -165,7 +167,12 @@ private fun HomeScreen(
                     .height(45.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Text("흔적들", style = TraceTheme.typography.headingMB, color = White, modifier = Modifier.height(24.dp))
+                Text(
+                    "흔적들",
+                    style = TraceTheme.typography.headingMB,
+                    color = White,
+                    modifier = Modifier.height(24.dp)
+                )
 
                 Spacer(Modifier.weight(1f))
 
@@ -211,14 +218,14 @@ private fun HomeScreen(
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    TabType.entries.forEachIndexed { index, type ->
+                    HomeTab.entries.forEachIndexed { index, type ->
                         TabSelector(
                             type = type,
                             selectedType = tabType,
                             onTabSelected = onTabTypeChange
                         )
 
-                        if (index != TabType.entries.size - 1) Spacer(Modifier.width(12.dp))
+                        if (index != HomeTab.entries.size - 1) Spacer(Modifier.width(12.dp))
                     }
                 }
             }
@@ -255,7 +262,7 @@ private fun HomeScreen(
 @Composable
 fun HomeScreenPreview() {
     HomeScreen(
-        tabType = TabType.ALL,
+        tabType = HomeTab.ALL,
         onTabTypeChange = {},
         navigateToPost = {},
         navigateToWritePost = {},
@@ -265,10 +272,131 @@ fun HomeScreenPreview() {
 }
 
 @Composable
-fun fakeLazyPagingPosts(): LazyPagingItems<PostFeed> {
+internal fun fakeLazyPagingPosts(): LazyPagingItems<PostFeed> {
     return flowOf(
         PagingData.from(
-            fakePostFeeds
+            listOf(
+                PostFeed(
+                    postType = PostType.GOOD_DEED,
+                    title = "깨끗한 공원 만들기",
+                    content = "오늘 공원에서 쓰레기를 줍고 깨끗한 환경을 만들었습니다. 주변 사람들이 함께 참여해주셨습니다.",
+                    nickname = "선행자1",
+                    createdAt = LocalDateTime.now(),
+                    viewCount = 150,
+                    commentCount = 5,
+                    isVerified = true,
+                    postId = 1, providerId = "1234", updatedAt = LocalDateTime.now()
+                ),
+                PostFeed(
+                    postType = PostType.GOOD_DEED,
+                    title = "무료 식사 제공",
+                    content = "어려운 이웃을 위해 무료로 식사를 제공했습니다. 작은 도움이지만 큰 의미가 있었습니다.",
+                    nickname = "선행자2",
+                    createdAt = LocalDateTime.now().minusMinutes(30),
+                    viewCount = 220,
+                    commentCount = 10,
+                    isVerified = false,
+                    imageUrl = "https://picsum.photos/200/300?random=2",
+                    postId = 2,
+                    providerId = "1234", updatedAt = LocalDateTime.now()
+                ),
+                PostFeed(
+                    postType = PostType.GOOD_DEED,
+                    title = "헌혈 참여",
+                    content = "지역 헌혈 행사에 참여하여 기부하였습니다. 많은 분들이 참여해주셔서 좋았습니다.",
+                    nickname = "선행자3",
+                    createdAt = LocalDateTime.now().minusMinutes(50),
+                    viewCount = 300,
+                    commentCount = 8,
+                    isVerified = true,
+                    postId = 2,
+                    providerId = "1234", updatedAt = LocalDateTime.now()
+                ),
+                PostFeed(
+                    postType = PostType.GOOD_DEED,
+                    title = "무료 도서 기부",
+                    content = "사용하지 않는 책을 기부하여 많은 사람들이 혜택을 볼 수 있게 했습니다.",
+                    nickname = "선행자4",
+                    createdAt = LocalDateTime.now().minusHours(1),
+                    viewCount = 175,
+                    commentCount = 12,
+                    isVerified = true,
+                    imageUrl = "https://picsum.photos/200/300?random=4",
+                    postId = 1,
+                    providerId = "1234", updatedAt = LocalDateTime.now()
+                ),
+                PostFeed(
+                    postType = PostType.GOOD_DEED,
+                    title = "환경 보호 캠페인",
+                    content = "자연을 보호하는 캠페인에 참여했습니다. 지구를 위한 작은 노력!",
+                    nickname = "선행자5",
+                    createdAt = LocalDateTime.now().minusHours(3),
+                    viewCount = 500,
+                    commentCount = 35,
+                    isVerified = false,
+                    postId = 1,
+                    providerId = "1234", updatedAt = LocalDateTime.now()
+                ),
+                PostFeed(
+                    postType = PostType.GOOD_DEED,
+                    title = "기부금 모금 활동",
+                    content = "소외된 이웃을 돕기 위해 기부금을 모금하였습니다.",
+                    nickname = "선행자6",
+                    createdAt = LocalDateTime.now().minusDays(6),
+                    viewCount = 400,
+                    commentCount = 28,
+                    isVerified = true,
+                    imageUrl = "https://picsum.photos/200/300?random=6",
+                    postId = 1, providerId = "1234", updatedAt = LocalDateTime.now()
+                ),
+                PostFeed(
+                    postType = PostType.GOOD_DEED,
+                    title = "청소년 멘토링 활동",
+                    content = "청소년들에게 멘토링을 통해 더 나은 미래를 꿈꾸도록 도왔습니다.",
+                    nickname = "선행자7",
+                    createdAt = LocalDateTime.now().minusDays(3),
+                    viewCount = 320,
+                    commentCount = 15,
+                    isVerified = true,
+                    postId = 1, providerId = "1234", updatedAt = LocalDateTime.now()
+                ),
+                PostFeed(
+                    postType = PostType.GOOD_DEED,
+                    title = "재활용 캠페인",
+                    content = "재활용을 촉진하는 캠페인에 참여해 재활용 활동을 지원했습니다.",
+                    nickname = "선행자8",
+                    createdAt = LocalDateTime.now().minusDays(4),
+                    viewCount = 220,
+                    commentCount = 18,
+                    isVerified = false,
+                    imageUrl = "https://picsum.photos/200/300?random=8",
+                    postId = 1, providerId = "1234", updatedAt = LocalDateTime.now()
+                ),
+                PostFeed(
+                    postType = PostType.GOOD_DEED,
+                    title = "노숙인들에게 의류 기부",
+                    content = "기부한 옷이 많은 노숙인들에게 도움이 되었길 바랍니다.",
+                    nickname = "선행자9",
+                    createdAt = LocalDateTime.now().minusDays(6),
+                    viewCount = 250,
+                    commentCount = 13,
+                    isVerified = false,
+                    imageUrl = "https://picsum.photos/200/300?random=9",
+                    postId = 1, providerId = "1234", updatedAt = LocalDateTime.now()
+                ),
+                PostFeed(
+                    postType = PostType.GOOD_DEED,
+                    title = "아름다운 거리 만들기",
+                    content = "동네에서 거리 청소와 아름다운 꽃밭을 조성했습니다.",
+                    nickname = "선행자10",
+                    createdAt = LocalDateTime.now().minusDays(8),
+                    viewCount = 100,
+                    commentCount = 5,
+                    isVerified = true,
+                    imageUrl = "https://picsum.photos/200/300?random=10",
+                    postId = 1, providerId = "1234", updatedAt = LocalDateTime.now()
+                )
+            )
         )
     ).collectAsLazyPagingItems()
 }

--- a/feature/home/src/main/java/com/example/home/graph/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/example/home/graph/home/HomeViewModel.kt
@@ -4,8 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
 import com.example.domain.model.post.HomeTab
-import com.example.domain.model.post.PostFeed
-import com.example.domain.model.post.PostType
 import com.example.domain.repository.PostRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/feature/home/src/main/java/com/example/home/graph/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/example/home/graph/home/HomeViewModel.kt
@@ -3,9 +3,9 @@ package com.example.home.graph.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
+import com.example.domain.model.post.HomeTab
 import com.example.domain.model.post.PostFeed
 import com.example.domain.model.post.PostType
-import com.example.domain.model.post.TabType
 import com.example.domain.repository.PostRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -29,17 +29,17 @@ class HomeViewModel @Inject constructor(
         _eventChannel.send(event)
     }
 
-    private val _tabType: MutableStateFlow<TabType> = MutableStateFlow(TabType.ALL)
+    private val _tabType: MutableStateFlow<HomeTab> = MutableStateFlow(HomeTab.ALL)
     val tabType = _tabType.asStateFlow()
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    val postPagingFlow = tabType
+    val postFeeds = tabType
         .flatMapLatest { tab ->
-            postRepository.getPostPagingFlow(tab)
+            postRepository.getPosts(tab)
         }
         .cachedIn(viewModelScope)
 
-    fun setTabType(tabType: TabType) {
+    fun setTabType(tabType: HomeTab) {
         _tabType.value = tabType
     }
 
@@ -49,129 +49,6 @@ class HomeViewModel @Inject constructor(
         data object NavigateToSearch : HomeEvent()
     }
 }
-
-val fakePostFeeds: List<PostFeed> = listOf(
-    PostFeed(
-        postType = PostType.GOOD_DEED,
-        title = "깨끗한 공원 만들기",
-        content = "오늘 공원에서 쓰레기를 줍고 깨끗한 환경을 만들었습니다. 주변 사람들이 함께 참여해주셨습니다.",
-        nickname = "선행자1",
-        createdAt = LocalDateTime.now(),
-        viewCount = 150,
-        commentCount = 5,
-        isVerified = true,
-        postId = 1, providerId = "1234", updatedAt = LocalDateTime.now()
-    ),
-    PostFeed(
-        postType = PostType.GOOD_DEED,
-        title = "무료 식사 제공",
-        content = "어려운 이웃을 위해 무료로 식사를 제공했습니다. 작은 도움이지만 큰 의미가 있었습니다.",
-        nickname = "선행자2",
-        createdAt = LocalDateTime.now().minusMinutes(30),
-        viewCount = 220,
-        commentCount = 10,
-        isVerified = false,
-        imageUrl = "https://picsum.photos/200/300?random=2",
-        postId = 2,
-        providerId = "1234", updatedAt = LocalDateTime.now()
-    ),
-    PostFeed(
-        postType = PostType.GOOD_DEED,
-        title = "헌혈 참여",
-        content = "지역 헌혈 행사에 참여하여 기부하였습니다. 많은 분들이 참여해주셔서 좋았습니다.",
-        nickname = "선행자3",
-        createdAt = LocalDateTime.now().minusMinutes(50),
-        viewCount = 300,
-        commentCount = 8,
-        isVerified = true,
-        postId = 2,
-        providerId = "1234", updatedAt = LocalDateTime.now()
-    ),
-    PostFeed(
-        postType = PostType.GOOD_DEED,
-        title = "무료 도서 기부",
-        content = "사용하지 않는 책을 기부하여 많은 사람들이 혜택을 볼 수 있게 했습니다.",
-        nickname = "선행자4",
-        createdAt = LocalDateTime.now().minusHours(1),
-        viewCount = 175,
-        commentCount = 12,
-        isVerified = true,
-        imageUrl = "https://picsum.photos/200/300?random=4",
-        postId = 1,
-        providerId = "1234", updatedAt = LocalDateTime.now()
-    ),
-    PostFeed(
-        postType = PostType.GOOD_DEED,
-        title = "환경 보호 캠페인",
-        content = "자연을 보호하는 캠페인에 참여했습니다. 지구를 위한 작은 노력!",
-        nickname = "선행자5",
-        createdAt = LocalDateTime.now().minusHours(3),
-        viewCount = 500,
-        commentCount = 35,
-        isVerified = false,
-        postId = 1,
-        providerId = "1234", updatedAt = LocalDateTime.now()
-    ),
-    PostFeed(
-        postType = PostType.GOOD_DEED,
-        title = "기부금 모금 활동",
-        content = "소외된 이웃을 돕기 위해 기부금을 모금하였습니다.",
-        nickname = "선행자6",
-        createdAt = LocalDateTime.now().minusDays(6),
-        viewCount = 400,
-        commentCount = 28,
-        isVerified = true,
-        imageUrl = "https://picsum.photos/200/300?random=6",
-        postId = 1, providerId = "1234", updatedAt = LocalDateTime.now()
-    ),
-    PostFeed(
-        postType = PostType.GOOD_DEED,
-        title = "청소년 멘토링 활동",
-        content = "청소년들에게 멘토링을 통해 더 나은 미래를 꿈꾸도록 도왔습니다.",
-        nickname = "선행자7",
-        createdAt = LocalDateTime.now().minusDays(3),
-        viewCount = 320,
-        commentCount = 15,
-        isVerified = true,
-        postId = 1, providerId = "1234", updatedAt = LocalDateTime.now()
-    ),
-    PostFeed(
-        postType = PostType.GOOD_DEED,
-        title = "재활용 캠페인",
-        content = "재활용을 촉진하는 캠페인에 참여해 재활용 활동을 지원했습니다.",
-        nickname = "선행자8",
-        createdAt = LocalDateTime.now().minusDays(4),
-        viewCount = 220,
-        commentCount = 18,
-        isVerified = false,
-        imageUrl = "https://picsum.photos/200/300?random=8",
-        postId = 1, providerId = "1234", updatedAt = LocalDateTime.now()
-    ),
-    PostFeed(
-        postType = PostType.GOOD_DEED,
-        title = "노숙인들에게 의류 기부",
-        content = "기부한 옷이 많은 노숙인들에게 도움이 되었길 바랍니다.",
-        nickname = "선행자9",
-        createdAt = LocalDateTime.now().minusDays(6),
-        viewCount = 250,
-        commentCount = 13,
-        isVerified = false,
-        imageUrl = "https://picsum.photos/200/300?random=9",
-        postId = 1, providerId = "1234", updatedAt = LocalDateTime.now()
-    ),
-    PostFeed(
-        postType = PostType.GOOD_DEED,
-        title = "아름다운 거리 만들기",
-        content = "동네에서 거리 청소와 아름다운 꽃밭을 조성했습니다.",
-        nickname = "선행자10",
-        createdAt = LocalDateTime.now().minusDays(8),
-        viewCount = 100,
-        commentCount = 5,
-        isVerified = true,
-        imageUrl = "https://picsum.photos/200/300?random=10",
-        postId = 1, providerId = "1234", updatedAt = LocalDateTime.now()
-    )
-)
 
 
 

--- a/feature/home/src/main/java/com/example/home/graph/home/component/TabSelector.kt
+++ b/feature/home/src/main/java/com/example/home/graph/home/component/TabSelector.kt
@@ -19,13 +19,13 @@ import com.example.designsystem.theme.PrimaryActive
 import com.example.designsystem.theme.TraceTheme
 import com.example.designsystem.theme.WarmGray
 import com.example.designsystem.theme.White
-import com.example.domain.model.post.TabType
+import com.example.domain.model.post.HomeTab
 
 @Composable
 internal fun TabSelector(
-    type: TabType,
-    selectedType: TabType,
-    onTabSelected: (TabType) -> Unit
+    type: HomeTab,
+    selectedType: HomeTab,
+    onTabSelected: (HomeTab) -> Unit
 ) {
     Box(
         modifier = Modifier

--- a/feature/home/src/main/java/com/example/home/graph/search/SearchScreen.kt
+++ b/feature/home/src/main/java/com/example/home/graph/search/SearchScreen.kt
@@ -30,8 +30,8 @@ import com.example.designsystem.R
 import com.example.designsystem.theme.Background
 import com.example.designsystem.theme.PrimaryDefault
 import com.example.domain.model.post.PostFeed
-import com.example.domain.model.post.SearchType
-import com.example.domain.model.post.TabType
+import com.example.domain.model.search.SearchTab
+import com.example.domain.model.search.SearchType
 import com.example.home.graph.home.fakeLazyPagingPosts
 import com.example.home.graph.search.SearchViewModel.SearchEvent
 import com.example.home.graph.search.component.SearchInitialView
@@ -49,7 +49,7 @@ internal fun SearchRoute(
     val isSearched by viewModel.isSearched.collectAsStateWithLifecycle()
     val searchType by viewModel.searchType.collectAsStateWithLifecycle()
     val tabType by viewModel.tabType.collectAsStateWithLifecycle()
-    val displayedPosts = viewModel.postPagingFlow.collectAsLazyPagingItems()
+    val displayedPosts = viewModel.postFeeds.collectAsLazyPagingItems()
 
     LaunchedEffect(isSearched) {
         viewModel.loadRecentKeywords()
@@ -90,11 +90,11 @@ private fun SearchScreen(
     recentKeywords: List<String>,
     isSearched: Boolean,
     searchType: SearchType,
-    tabType: TabType,
+    tabType: SearchTab,
     displayedPosts: LazyPagingItems<PostFeed>,
     onKeywordInputChange: (String) -> Unit,
     onSearchTypeChange: (SearchType) -> Unit,
-    onTabTypeChange: (TabType) -> Unit,
+    onTabTypeChange: (SearchTab) -> Unit,
     searchByInput: () -> Unit,
     searchByRecentKeyword: (String) -> Unit,
     removeKeyword: (String) -> Unit,
@@ -182,7 +182,7 @@ private fun SearchScreenPreview() {
         recentKeywords = listOf("선행", "제비", "흥부", "선행자", "쓰레기"),
         isSearched = true,
         searchType = SearchType.CONTENT,
-        tabType = TabType.ALL,
+        tabType = SearchTab.ALL,
         displayedPosts = fakeLazyPagingPosts(),
         onKeywordInputChange = {},
         clearKeywords = {},

--- a/feature/home/src/main/java/com/example/home/graph/search/SearchViewModel.kt
+++ b/feature/home/src/main/java/com/example/home/graph/search/SearchViewModel.kt
@@ -5,8 +5,8 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
 import com.example.common.event.EventHelper
 import com.example.common.event.TraceEvent
-import com.example.domain.model.post.SearchType
-import com.example.domain.model.post.TabType
+import com.example.domain.model.search.SearchTab
+import com.example.domain.model.search.SearchType
 import com.example.domain.model.search.SearchCondition
 import com.example.domain.repository.SearchRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -46,11 +46,11 @@ class SearchViewModel @Inject constructor(
     private val _searchType = MutableStateFlow(SearchType.ALL)
     val searchType = _searchType.asStateFlow()
 
-    private val _tabType = MutableStateFlow(TabType.ALL)
+    private val _tabType = MutableStateFlow(SearchTab.ALL)
     val tabType = _tabType.asStateFlow()
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    val postPagingFlow = combine(
+    val postFeeds = combine(
         _keywordInput,
         _tabType,
         _searchType,
@@ -80,7 +80,7 @@ class SearchViewModel @Inject constructor(
         _searchType.value = searchType
     }
 
-    fun setTabType(tabType: TabType) {
+    fun setTabType(tabType: SearchTab) {
         _tabType.value = tabType
     }
 

--- a/feature/home/src/main/java/com/example/home/graph/search/component/SearchResultView.kt
+++ b/feature/home/src/main/java/com/example/home/graph/search/component/SearchResultView.kt
@@ -39,17 +39,17 @@ import com.example.designsystem.theme.PrimaryDefault
 import com.example.designsystem.theme.TabIndicator
 import com.example.designsystem.theme.TraceTheme
 import com.example.domain.model.post.PostFeed
-import com.example.domain.model.post.SearchType
-import com.example.domain.model.post.TabType
+import com.example.domain.model.search.SearchTab
+import com.example.domain.model.search.SearchType
 
 
 @Composable
 internal fun SearchResultView(
     searchType: SearchType,
-    tabType: TabType,
+    tabType: SearchTab,
     displayedPosts: LazyPagingItems<PostFeed>,
     onSearchTypeChange: (SearchType) -> Unit,
-    onTabTypeChange: (TabType) -> Unit,
+    onTabTypeChange: (SearchTab) -> Unit,
     navigateToPost: (Int) -> Unit,
 ) {
     val tabs = SearchType.entries

--- a/feature/home/src/main/java/com/example/home/graph/search/component/TabTypeDropdownMenu.kt
+++ b/feature/home/src/main/java/com/example/home/graph/search/component/TabTypeDropdownMenu.kt
@@ -22,16 +22,16 @@ import androidx.compose.ui.unit.dp
 import com.example.common.util.clickable
 import com.example.designsystem.theme.Background
 import com.example.designsystem.theme.TraceTheme
-import com.example.domain.model.post.TabType
+import com.example.domain.model.search.SearchTab
 
 @Composable
 internal fun TabTypeDropdownMenu(
     expanded: Boolean,
     onDismiss: () -> Unit,
-    selectedTabType: TabType,
-    onTabTypeChange: (TabType) -> Unit
+    selectedTabType: SearchTab,
+    onTabTypeChange: (SearchTab) -> Unit
 ) {
-    val entries = TabType.entries
+    val entries = SearchTab.entries
 
     if (expanded) {
         DropdownMenu(
@@ -82,7 +82,7 @@ private fun TabTypeDropdownMenuPreview() {
             expanded = true,
             onTabTypeChange = {},
             onDismiss = {},
-            selectedTabType = TabType.ALL
+            selectedTabType = SearchTab.ALL
         )
     }
 

--- a/feature/mypage/src/main/java/com/example/mypage/graph/mypage/MyPageScreen.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/graph/mypage/MyPageScreen.kt
@@ -231,29 +231,33 @@ private fun MyPageScreen(
             }
 
             items(displayedPosts.itemCount) { index ->
-                displayedPosts[index]?.let { postFeed ->
-                    PostFeed(postFeed, navigateToPost = { navigateToPost(postFeed.postId) })
+                Box {
+                    Column {
+                        displayedPosts[index]?.let { postFeed ->
+                            PostFeed(postFeed, navigateToPost = { navigateToPost(postFeed.postId) })
 
-                    Spacer(Modifier.height(8.dp))
+                            Spacer(Modifier.height(8.dp))
 
-                    HorizontalDivider(
-                        modifier = Modifier
-                            .fillMaxWidth(),
-                        thickness = 1.dp,
-                        color = GrayLine
-                    )
+                            HorizontalDivider(
+                                modifier = Modifier
+                                    .fillMaxWidth(),
+                                thickness = 1.dp,
+                                color = GrayLine
+                            )
 
-                    Spacer(Modifier.height(15.dp))
+                            Spacer(Modifier.height(15.dp))
+                        }
+                    }
+
+                    if (isRefreshing || isAppending) {
+                        CircularProgressIndicator(
+                            color = PrimaryDefault, modifier = Modifier.align(
+                                if (isRefreshing) Alignment.Center else Alignment.BottomCenter
+                            )
+                        )
+                    }
                 }
             }
-        }
-
-        if (isRefreshing || isAppending) {
-            CircularProgressIndicator(
-                color = PrimaryDefault, modifier = Modifier.align(
-                    if (isRefreshing) Alignment.Center else Alignment.BottomCenter
-                )
-            )
         }
     }
 

--- a/feature/mypage/src/main/java/com/example/mypage/graph/mypage/MyPageScreen.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/graph/mypage/MyPageScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.TabRowDefaults
@@ -32,6 +33,9 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.paging.PagingData
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
 import com.example.common.util.clickable
 import com.example.designsystem.R
 import com.example.designsystem.component.PostFeed
@@ -43,8 +47,11 @@ import com.example.designsystem.theme.TabIndicator
 import com.example.designsystem.theme.TraceTheme
 import com.example.domain.model.mypage.MyPageTab
 import com.example.domain.model.post.PostFeed
+import com.example.domain.model.post.PostType
 import com.example.domain.model.user.UserInfo
 import com.example.mypage.graph.mypage.MyPageViewModel.MyPageEvent
+import kotlinx.coroutines.flow.flowOf
+import java.time.LocalDateTime
 
 
 @Composable
@@ -56,9 +63,7 @@ internal fun MyPageRoute(
 ) {
     val userInfo by viewModel.userInfo.collectAsStateWithLifecycle()
     val tabType by viewModel.tabType.collectAsStateWithLifecycle()
-    val writtenPosts by viewModel.writtenPosts.collectAsStateWithLifecycle()
-    val commentedPosts by viewModel.commentedPosts.collectAsStateWithLifecycle()
-    val reactedPosts by viewModel.reactedPosts.collectAsStateWithLifecycle()
+    val displayedPosts = viewModel.displayedPosts.collectAsLazyPagingItems()
 
     LaunchedEffect(Unit) {
         viewModel.eventChannel.collect { event ->
@@ -88,11 +93,7 @@ internal fun MyPageRoute(
     MyPageScreen(
         userInfo = userInfo,
         tabType = tabType,
-        displayedPosts = when (tabType) {
-            MyPageTab.WRITTEN_POSTS -> writtenPosts
-            MyPageTab.COMMENTED_POSTS -> commentedPosts
-            MyPageTab.REACTED_POSTS -> reactedPosts
-        },
+        displayedPosts = displayedPosts,
         onTabTypeChange = viewModel::setTabType,
         navigateToPost = { postId -> viewModel.onEvent(MyPageEvent.NavigateToPost(postId)) },
         navigateToEditProfile = { viewModel.onEvent(MyPageEvent.NavigateToEditProfile) },
@@ -105,7 +106,7 @@ internal fun MyPageRoute(
 private fun MyPageScreen(
     userInfo: UserInfo,
     tabType: MyPageTab,
-    displayedPosts: List<PostFeed>,
+    displayedPosts: LazyPagingItems<PostFeed>,
     onTabTypeChange: (MyPageTab) -> Unit,
     navigateToPost: (Int) -> Unit,
     navigateToEditProfile: () -> Unit,
@@ -219,19 +220,21 @@ private fun MyPageScreen(
             Spacer(Modifier.height(20.dp))
         }
 
-        items(displayedPosts.size) { index ->
-            PostFeed(displayedPosts[index], navigateToPost = { navigateToPost(1) })
+        items(displayedPosts.itemCount) { index ->
+            displayedPosts[index]?.let {
+                PostFeed(it, navigateToPost = { navigateToPost(1) })
 
-            Spacer(Modifier.height(8.dp))
+                Spacer(Modifier.height(8.dp))
 
-            Spacer(
-                Modifier
-                    .fillMaxWidth()
-                    .height(1.dp)
-                    .background(GrayLine)
-            )
+                HorizontalDivider(
+                    modifier = Modifier
+                        .fillMaxWidth(),
+                    thickness = 1.dp,
+                    color = GrayLine
+                )
 
-            Spacer(Modifier.height(15.dp))
+                Spacer(Modifier.height(15.dp))
+            }
         }
     }
 }
@@ -243,9 +246,139 @@ fun MyPageScreenPreview() {
         userInfo = UserInfo("닉네임", null, 0, 0),
         navigateToEditProfile = {},
         navigateToSetting = {},
-        displayedPosts = emptyList(),
+        displayedPosts = fakeLazyPagingPosts(),
         tabType = MyPageTab.WRITTEN_POSTS,
         navigateToPost = {},
         onTabTypeChange = {}
     )
+}
+
+@Composable
+private fun fakeLazyPagingPosts(): LazyPagingItems<PostFeed> {
+    return flowOf(
+        PagingData.from(
+            listOf(
+                PostFeed(
+                    postType = PostType.GOOD_DEED,
+                    title = "깨끗한 공원 만들기",
+                    content = "오늘 공원에서 쓰레기를 줍고 깨끗한 환경을 만들었습니다. 주변 사람들이 함께 참여해주셨습니다.",
+                    nickname = "선행자1",
+                    createdAt = LocalDateTime.now(),
+                    viewCount = 150,
+                    commentCount = 5,
+                    isVerified = true,
+                    postId = 1, providerId = "1234", updatedAt = LocalDateTime.now()
+                ),
+                PostFeed(
+                    postType = PostType.GOOD_DEED,
+                    title = "무료 식사 제공",
+                    content = "어려운 이웃을 위해 무료로 식사를 제공했습니다. 작은 도움이지만 큰 의미가 있었습니다.",
+                    nickname = "선행자2",
+                    createdAt = LocalDateTime.now().minusMinutes(30),
+                    viewCount = 220,
+                    commentCount = 10,
+                    isVerified = false,
+                    imageUrl = "https://picsum.photos/200/300?random=2",
+                    postId = 2,
+                    providerId = "1234", updatedAt = LocalDateTime.now()
+                ),
+                PostFeed(
+                    postType = PostType.GOOD_DEED,
+                    title = "헌혈 참여",
+                    content = "지역 헌혈 행사에 참여하여 기부하였습니다. 많은 분들이 참여해주셔서 좋았습니다.",
+                    nickname = "선행자3",
+                    createdAt = LocalDateTime.now().minusMinutes(50),
+                    viewCount = 300,
+                    commentCount = 8,
+                    isVerified = true,
+                    postId = 2,
+                    providerId = "1234", updatedAt = LocalDateTime.now()
+                ),
+                PostFeed(
+                    postType = PostType.GOOD_DEED,
+                    title = "무료 도서 기부",
+                    content = "사용하지 않는 책을 기부하여 많은 사람들이 혜택을 볼 수 있게 했습니다.",
+                    nickname = "선행자4",
+                    createdAt = LocalDateTime.now().minusHours(1),
+                    viewCount = 175,
+                    commentCount = 12,
+                    isVerified = true,
+                    imageUrl = "https://picsum.photos/200/300?random=4",
+                    postId = 1,
+                    providerId = "1234", updatedAt = LocalDateTime.now()
+                ),
+                PostFeed(
+                    postType = PostType.GOOD_DEED,
+                    title = "환경 보호 캠페인",
+                    content = "자연을 보호하는 캠페인에 참여했습니다. 지구를 위한 작은 노력!",
+                    nickname = "선행자5",
+                    createdAt = LocalDateTime.now().minusHours(3),
+                    viewCount = 500,
+                    commentCount = 35,
+                    isVerified = false,
+                    postId = 1,
+                    providerId = "1234", updatedAt = LocalDateTime.now()
+                ),
+                PostFeed(
+                    postType = PostType.GOOD_DEED,
+                    title = "기부금 모금 활동",
+                    content = "소외된 이웃을 돕기 위해 기부금을 모금하였습니다.",
+                    nickname = "선행자6",
+                    createdAt = LocalDateTime.now().minusDays(6),
+                    viewCount = 400,
+                    commentCount = 28,
+                    isVerified = true,
+                    imageUrl = "https://picsum.photos/200/300?random=6",
+                    postId = 1, providerId = "1234", updatedAt = LocalDateTime.now()
+                ),
+                PostFeed(
+                    postType = PostType.GOOD_DEED,
+                    title = "청소년 멘토링 활동",
+                    content = "청소년들에게 멘토링을 통해 더 나은 미래를 꿈꾸도록 도왔습니다.",
+                    nickname = "선행자7",
+                    createdAt = LocalDateTime.now().minusDays(3),
+                    viewCount = 320,
+                    commentCount = 15,
+                    isVerified = true,
+                    postId = 1, providerId = "1234", updatedAt = LocalDateTime.now()
+                ),
+                PostFeed(
+                    postType = PostType.GOOD_DEED,
+                    title = "재활용 캠페인",
+                    content = "재활용을 촉진하는 캠페인에 참여해 재활용 활동을 지원했습니다.",
+                    nickname = "선행자8",
+                    createdAt = LocalDateTime.now().minusDays(4),
+                    viewCount = 220,
+                    commentCount = 18,
+                    isVerified = false,
+                    imageUrl = "https://picsum.photos/200/300?random=8",
+                    postId = 1, providerId = "1234", updatedAt = LocalDateTime.now()
+                ),
+                PostFeed(
+                    postType = PostType.GOOD_DEED,
+                    title = "노숙인들에게 의류 기부",
+                    content = "기부한 옷이 많은 노숙인들에게 도움이 되었길 바랍니다.",
+                    nickname = "선행자9",
+                    createdAt = LocalDateTime.now().minusDays(6),
+                    viewCount = 250,
+                    commentCount = 13,
+                    isVerified = false,
+                    imageUrl = "https://picsum.photos/200/300?random=9",
+                    postId = 1, providerId = "1234", updatedAt = LocalDateTime.now()
+                ),
+                PostFeed(
+                    postType = PostType.GOOD_DEED,
+                    title = "아름다운 거리 만들기",
+                    content = "동네에서 거리 청소와 아름다운 꽃밭을 조성했습니다.",
+                    nickname = "선행자10",
+                    createdAt = LocalDateTime.now().minusDays(8),
+                    viewCount = 100,
+                    commentCount = 5,
+                    isVerified = true,
+                    imageUrl = "https://picsum.photos/200/300?random=10",
+                    postId = 1, providerId = "1234", updatedAt = LocalDateTime.now()
+                )
+            )
+        )
+    ).collectAsLazyPagingItems()
 }

--- a/feature/mypage/src/main/java/com/example/mypage/graph/mypage/MyPageScreen.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/graph/mypage/MyPageScreen.kt
@@ -221,8 +221,8 @@ private fun MyPageScreen(
         }
 
         items(displayedPosts.itemCount) { index ->
-            displayedPosts[index]?.let {
-                PostFeed(it, navigateToPost = { navigateToPost(1) })
+            displayedPosts[index]?.let { postFeed ->
+                PostFeed(postFeed, navigateToPost = { navigateToPost(postFeed.postId) })
 
                 Spacer(Modifier.height(8.dp))
 

--- a/feature/mypage/src/main/java/com/example/mypage/graph/mypage/MyPageScreen.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/graph/mypage/MyPageScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
@@ -33,6 +34,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.paging.LoadState
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -43,6 +45,7 @@ import com.example.designsystem.component.ProfileImage
 import com.example.designsystem.theme.Background
 import com.example.designsystem.theme.Black
 import com.example.designsystem.theme.GrayLine
+import com.example.designsystem.theme.PrimaryDefault
 import com.example.designsystem.theme.TabIndicator
 import com.example.designsystem.theme.TraceTheme
 import com.example.domain.model.mypage.MyPageTab
@@ -114,129 +117,146 @@ private fun MyPageScreen(
 ) {
     val tabs = MyPageTab.entries
 
-    LazyColumn(
+    val isRefreshing = displayedPosts.loadState.refresh is LoadState.Loading
+    val isAppending = displayedPosts.loadState.append is LoadState.Loading
+
+    Box(
         modifier = Modifier
             .fillMaxSize()
-            .padding(
-                top = 13.dp, start = 20.dp, end = 14.dp
-            )
     ) {
-        item {
-            Box(
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Image(
-                    painter = painterResource(R.drawable.setting_ic),
-                    contentDescription = "설정",
-                    modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .clickable {
-                            navigateToSetting()
-                        }
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(
+                    top = 13.dp, start = 20.dp, end = 14.dp
                 )
-            }
-
-            Spacer(Modifier.height(5.dp))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                ProfileImage(
-                    profileImageUrl = userInfo.profileImageUrl,
-                    imageSize = if (userInfo.profileImageUrl != null) 96.dp else 86.dp,
-                    paddingValue = if (userInfo.profileImageUrl != null) 2.dp else 7.dp,
-                    strokeWidth = 10f,
-                )
-
-                Spacer(Modifier.width(20.dp))
-
-                Column {
-                    Row() {
-                        Text(userInfo.name, style = TraceTheme.typography.headingLB)
-
-                        Spacer(Modifier.width(2.dp))
-
-                        Image(
-                            painter = painterResource(R.drawable.arrow_right),
-                            contentDescription = "설정",
-                            modifier = Modifier
-                                .clickable {
-                                    navigateToEditProfile()
-                                }
-                        )
-                    }
-
-                    Spacer(Modifier.height(10.dp))
-
-                    Text(
-                        "선행 점수 ${userInfo.verificationScore}",
-                        style = TraceTheme.typography.bodyMR.copy(
-                            fontSize = 15.sp,
-                            lineHeight = 19.sp
-                        )
-                    )
-
-                    Spacer(Modifier.height(5.dp))
-
-                    Text(
-                        "선행 마크 ${userInfo.verificationCount}",
-                        style = TraceTheme.typography.bodyMR.copy(
-                            fontSize = 15.sp,
-                            lineHeight = 19.sp
-                        )
-                    )
-                }
-            }
-
-            Spacer(Modifier.height(28.dp))
-
-            TabRow(
-                selectedTabIndex = tabs.indexOf(tabType),
-                containerColor = Background,
-                contentColor = Black,
-                indicator = { tabPositions ->
-                    TabRowDefaults.SecondaryIndicator(
-                        color = TabIndicator,
+        ) {
+            item {
+                Box(
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Image(
+                        painter = painterResource(R.drawable.setting_ic),
+                        contentDescription = "설정",
                         modifier = Modifier
-                            .tabIndicatorOffset(tabPositions[tabs.indexOf(tabType)])
+                            .align(Alignment.TopEnd)
+                            .clickable {
+                                navigateToSetting()
+                            }
                     )
                 }
-            ) {
-                tabs.forEach { tab ->
-                    Tab(
-                        selected = tab == tabType,
-                        onClick = { onTabTypeChange(tab) },
-                        text = {
-                            Text(
-                                tab.label,
-                                style = TraceTheme.typography.myPageTab
+
+                Spacer(Modifier.height(5.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    ProfileImage(
+                        profileImageUrl = userInfo.profileImageUrl,
+                        imageSize = if (userInfo.profileImageUrl != null) 96.dp else 86.dp,
+                        paddingValue = if (userInfo.profileImageUrl != null) 2.dp else 7.dp,
+                        strokeWidth = 10f,
+                    )
+
+                    Spacer(Modifier.width(20.dp))
+
+                    Column {
+                        Row() {
+                            Text(userInfo.name, style = TraceTheme.typography.headingLB)
+
+                            Spacer(Modifier.width(2.dp))
+
+                            Image(
+                                painter = painterResource(R.drawable.arrow_right),
+                                contentDescription = "설정",
+                                modifier = Modifier
+                                    .clickable {
+                                        navigateToEditProfile()
+                                    }
                             )
                         }
+
+                        Spacer(Modifier.height(10.dp))
+
+                        Text(
+                            "선행 점수 ${userInfo.verificationScore}",
+                            style = TraceTheme.typography.bodyMR.copy(
+                                fontSize = 15.sp,
+                                lineHeight = 19.sp
+                            )
+                        )
+
+                        Spacer(Modifier.height(5.dp))
+
+                        Text(
+                            "선행 마크 ${userInfo.verificationCount}",
+                            style = TraceTheme.typography.bodyMR.copy(
+                                fontSize = 15.sp,
+                                lineHeight = 19.sp
+                            )
+                        )
+                    }
+                }
+
+                Spacer(Modifier.height(28.dp))
+
+                TabRow(
+                    selectedTabIndex = tabs.indexOf(tabType),
+                    containerColor = Background,
+                    contentColor = Black,
+                    indicator = { tabPositions ->
+                        TabRowDefaults.SecondaryIndicator(
+                            color = TabIndicator,
+                            modifier = Modifier
+                                .tabIndicatorOffset(tabPositions[tabs.indexOf(tabType)])
+                        )
+                    }
+                ) {
+                    tabs.forEach { tab ->
+                        Tab(
+                            selected = tab == tabType,
+                            onClick = { onTabTypeChange(tab) },
+                            text = {
+                                Text(
+                                    tab.label,
+                                    style = TraceTheme.typography.myPageTab
+                                )
+                            }
+                        )
+                    }
+                }
+
+                Spacer(Modifier.height(20.dp))
+            }
+
+            items(displayedPosts.itemCount) { index ->
+                displayedPosts[index]?.let { postFeed ->
+                    PostFeed(postFeed, navigateToPost = { navigateToPost(postFeed.postId) })
+
+                    Spacer(Modifier.height(8.dp))
+
+                    HorizontalDivider(
+                        modifier = Modifier
+                            .fillMaxWidth(),
+                        thickness = 1.dp,
+                        color = GrayLine
                     )
+
+                    Spacer(Modifier.height(15.dp))
                 }
             }
-
-            Spacer(Modifier.height(20.dp))
         }
 
-        items(displayedPosts.itemCount) { index ->
-            displayedPosts[index]?.let { postFeed ->
-                PostFeed(postFeed, navigateToPost = { navigateToPost(postFeed.postId) })
-
-                Spacer(Modifier.height(8.dp))
-
-                HorizontalDivider(
-                    modifier = Modifier
-                        .fillMaxWidth(),
-                    thickness = 1.dp,
-                    color = GrayLine
+        if (isRefreshing || isAppending) {
+            CircularProgressIndicator(
+                color = PrimaryDefault, modifier = Modifier.align(
+                    if (isRefreshing) Alignment.Center else Alignment.BottomCenter
                 )
-
-                Spacer(Modifier.height(15.dp))
-            }
+            )
         }
     }
+
 }
 
 @Preview(showBackground = true)

--- a/feature/mypage/src/main/java/com/example/mypage/graph/mypage/MyPageViewModel.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/graph/mypage/MyPageViewModel.kt
@@ -2,15 +2,19 @@ package com.example.mypage.graph.mypage
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.paging.cachedIn
 import com.example.domain.model.mypage.MyPageTab
 import com.example.domain.model.post.PostFeed
 import com.example.domain.model.post.PostType
 import com.example.domain.model.user.UserInfo
+import com.example.domain.repository.PostRepository
 import com.example.domain.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
@@ -18,6 +22,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
+    private val postRepository: PostRepository,
     private val userRepository: UserRepository,
 ) : ViewModel() {
     private val _eventChannel = Channel<MyPageEvent>()
@@ -41,14 +46,12 @@ class MyPageViewModel @Inject constructor(
     private val _tapType = MutableStateFlow(MyPageTab.WRITTEN_POSTS)
     val tabType = _tapType.asStateFlow()
 
-    private val _writtenPosts: MutableStateFlow<List<PostFeed>> = MutableStateFlow(fakePostFeeds)
-    val writtenPosts = _writtenPosts.asStateFlow()
-
-    private val _commentedPosts: MutableStateFlow<List<PostFeed>> = MutableStateFlow(emptyList())
-    val commentedPosts = _commentedPosts.asStateFlow()
-
-    private val _reactedPosts: MutableStateFlow<List<PostFeed>> = MutableStateFlow(fakePostFeeds)
-    val reactedPosts = _reactedPosts.asStateFlow()
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val displayedPosts = tabType
+        .flatMapLatest { tab ->
+            postRepository.getMyPosts(tab)
+        }
+        .cachedIn(viewModelScope)
 
     fun getUserInfo() = viewModelScope.launch {
         userRepository.getUserInfo().onSuccess { userInfo ->
@@ -68,127 +71,5 @@ class MyPageViewModel @Inject constructor(
 }
 
 
-val fakePostFeeds: List<PostFeed> = listOf(
-    PostFeed(
-        postType = PostType.GOOD_DEED,
-        title = "깨끗한 공원 만들기",
-        content = "오늘 공원에서 쓰레기를 줍고 깨끗한 환경을 만들었습니다. 주변 사람들이 함께 참여해주셨습니다.",
-        nickname = "선행자1",
-        createdAt = LocalDateTime.now(),
-        viewCount = 150,
-        commentCount = 5,
-        isVerified = true,
-        postId = 1, providerId = "1234", updatedAt = LocalDateTime.now()
-    ),
-    PostFeed(
-        postType = PostType.GOOD_DEED,
-        title = "무료 식사 제공",
-        content = "어려운 이웃을 위해 무료로 식사를 제공했습니다. 작은 도움이지만 큰 의미가 있었습니다.",
-        nickname = "선행자2",
-        createdAt = LocalDateTime.now().minusMinutes(30),
-        viewCount = 220,
-        commentCount = 10,
-        isVerified = false,
-        imageUrl = "https://picsum.photos/200/300?random=2",
-        postId = 2,
-        providerId = "1234", updatedAt = LocalDateTime.now()
-    ),
-    PostFeed(
-        postType = PostType.GOOD_DEED,
-        title = "헌혈 참여",
-        content = "지역 헌혈 행사에 참여하여 기부하였습니다. 많은 분들이 참여해주셔서 좋았습니다.",
-        nickname = "선행자3",
-        createdAt = LocalDateTime.now().minusMinutes(50),
-        viewCount = 300,
-        commentCount = 8,
-        isVerified = true,
-        postId = 2,
-        providerId = "1234", updatedAt = LocalDateTime.now()
-    ),
-    PostFeed(
-        postType = PostType.GOOD_DEED,
-        title = "무료 도서 기부",
-        content = "사용하지 않는 책을 기부하여 많은 사람들이 혜택을 볼 수 있게 했습니다.",
-        nickname = "선행자4",
-        createdAt = LocalDateTime.now().minusHours(1),
-        viewCount = 175,
-        commentCount = 12,
-        isVerified = true,
-        imageUrl = "https://picsum.photos/200/300?random=4",
-        postId = 1,
-        providerId = "1234", updatedAt = LocalDateTime.now()
-    ),
-    PostFeed(
-        postType = PostType.GOOD_DEED,
-        title = "환경 보호 캠페인",
-        content = "자연을 보호하는 캠페인에 참여했습니다. 지구를 위한 작은 노력!",
-        nickname = "선행자5",
-        createdAt = LocalDateTime.now().minusHours(3),
-        viewCount = 500,
-        commentCount = 35,
-        isVerified = false,
-        postId = 1,
-        providerId = "1234", updatedAt = LocalDateTime.now()
-    ),
-    PostFeed(
-        postType = PostType.GOOD_DEED,
-        title = "기부금 모금 활동",
-        content = "소외된 이웃을 돕기 위해 기부금을 모금하였습니다.",
-        nickname = "선행자6",
-        createdAt = LocalDateTime.now().minusDays(6),
-        viewCount = 400,
-        commentCount = 28,
-        isVerified = true,
-        imageUrl = "https://picsum.photos/200/300?random=6",
-        postId = 1, providerId = "1234", updatedAt = LocalDateTime.now()
-    ),
-    PostFeed(
-        postType = PostType.GOOD_DEED,
-        title = "청소년 멘토링 활동",
-        content = "청소년들에게 멘토링을 통해 더 나은 미래를 꿈꾸도록 도왔습니다.",
-        nickname = "선행자7",
-        createdAt = LocalDateTime.now().minusDays(3),
-        viewCount = 320,
-        commentCount = 15,
-        isVerified = true,
-        postId = 1, providerId = "1234", updatedAt = LocalDateTime.now()
-    ),
-    PostFeed(
-        postType = PostType.GOOD_DEED,
-        title = "재활용 캠페인",
-        content = "재활용을 촉진하는 캠페인에 참여해 재활용 활동을 지원했습니다.",
-        nickname = "선행자8",
-        createdAt = LocalDateTime.now().minusDays(4),
-        viewCount = 220,
-        commentCount = 18,
-        isVerified = false,
-        imageUrl = "https://picsum.photos/200/300?random=8",
-        postId = 1, providerId = "1234", updatedAt = LocalDateTime.now()
-    ),
-    PostFeed(
-        postType = PostType.GOOD_DEED,
-        title = "노숙인들에게 의류 기부",
-        content = "기부한 옷이 많은 노숙인들에게 도움이 되었길 바랍니다.",
-        nickname = "선행자9",
-        createdAt = LocalDateTime.now().minusDays(6),
-        viewCount = 250,
-        commentCount = 13,
-        isVerified = false,
-        imageUrl = "https://picsum.photos/200/300?random=9",
-        postId = 1, providerId = "1234", updatedAt = LocalDateTime.now()
-    ),
-    PostFeed(
-        postType = PostType.GOOD_DEED,
-        title = "아름다운 거리 만들기",
-        content = "동네에서 거리 청소와 아름다운 꽃밭을 조성했습니다.",
-        nickname = "선행자10",
-        createdAt = LocalDateTime.now().minusDays(8),
-        viewCount = 100,
-        commentCount = 5,
-        isVerified = true,
-        imageUrl = "https://picsum.photos/200/300?random=10",
-        postId = 1, providerId = "1234", updatedAt = LocalDateTime.now()
-    )
-)
 
 


### PR DESCRIPTION
### 🚀 변경 사항 🚀
- 내가 쓴 글 불러오기
- 내가 댓글 단 글 불러오기
- 내가 감정표현단 글 불러오기
- Refactor: 기존 tabType 클래스 -> HomeTab, SearchTab으로 분리

### 📸 스크린샷

### 📖 배운 것

### 📝 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added paginated post feeds for the My Page screen, enhancing browsing experience with efficient data loading.
  - Introduced new tab categories for search and post screens, enabling refined content filtering.
  - Added support for fetching user-specific posts with cursor-based pagination.

- **Refactor**
  - Renamed and unified tab enums for Home and Search screens to improve clarity.
  - Updated data sources and repositories to support new tab types and paging mechanisms.
  - Consolidated multiple post lists in My Page into a single paginated stream for streamlined state management.
  - Enhanced preview and testing with expanded fake post data sets reflecting real usage scenarios.
  - Replaced multiple separate post lists in My Page with a single paginated stream and updated UI to support paging states.

- **Bug Fixes**
  - Improved pagination logic to prevent redundant data loading and ensure smooth scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->